### PR TITLE
Sn make less verbose

### DIFF
--- a/python/utils/gcp_utils.py
+++ b/python/utils/gcp_utils.py
@@ -10,7 +10,11 @@ COPY = "copy"
 
 
 class GCPCloudFunctions:
-    """List contents of a GCS bucket. Does NOT take in a token and auths as current user"""
+    """
+    A class to interact with Google Cloud Storage (GCS) for various file operations.
+    Authenticates using the default credentials and sets up the storage client.
+    Does NOT use Token class for authentication.
+    """
 
     def __init__(self) -> None:
         """

--- a/python/utils/gcp_utils.py
+++ b/python/utils/gcp_utils.py
@@ -187,7 +187,8 @@ class GCPCloudFunctions:
             files_to_delete: list[str],
             workers: int = 5,
             max_retries: int = 3,
-            verbose: bool = False
+            verbose: bool = False,
+            job_complete_for_logging: int = 500
     ) -> None:
         """
         Delete multiple cloud files in parallel using multi-threading.
@@ -197,6 +198,7 @@ class GCPCloudFunctions:
             workers (int, optional): Number of worker threads. Defaults to 5.
             max_retries (int, optional): Maximum number of retries. Defaults to 3.
             verbose (bool, optional): Whether to log each job's success. Defaults to False.
+            job_complete_for_logging (int, optional): The number of jobs to complete before logging. Defaults to 500.
         """
         list_of_jobs_args_list = [[file_path] for file_path in files_to_delete]
 
@@ -207,7 +209,8 @@ class GCPCloudFunctions:
             max_retries=max_retries,
             fail_on_error=True,
             verbose=verbose,
-            collect_output=False
+            collect_output=False,
+            jobs_complete_for_logging=job_complete_for_logging
         )
 
     def validate_file_pair(self, source_file: str, full_destination_path: str) -> Optional[dict]:
@@ -230,7 +233,8 @@ class GCPCloudFunctions:
             files_to_validate: list[dict],
             log_difference: bool,
             workers: int = 5,
-            max_retries: int = 3
+            max_retries: int = 3,
+            job_complete_for_logging: int = 500
     ) -> list[dict]:
         """
         Validate if multiple cloud files are identical based on their MD5 hashes using multithreading.
@@ -241,6 +245,7 @@ class GCPCloudFunctions:
                                    this at the start of a copy/move operation to check if files are already copied.
             workers (int, optional): Number of worker threads. Defaults to 5.
             max_retries (int, optional): Maximum number of retries for all jobs. Defaults to 3.
+            job_complete_for_logging (int, optional): The number of jobs to complete before logging. Defaults to 500.
 
         Returns:
             list[Dict]: List of dictionaries containing files that are not identical.
@@ -256,7 +261,8 @@ class GCPCloudFunctions:
             function=self.validate_file_pair,
             list_of_jobs_args_list=jobs,
             collect_output=True,
-            max_retries=max_retries
+            max_retries=max_retries,
+            jobs_complete_for_logging=job_complete_for_logging
         )
 
         # If only here so linting will be happy
@@ -312,7 +318,12 @@ class GCPCloudFunctions:
         return None
 
     def move_or_copy_multiple_files(
-            self, files_to_move: list[dict], action: str, workers: int, max_retries: int, verbose: bool = False
+            self, files_to_move: list[dict],
+            action: str,
+            workers: int,
+            max_retries: int,
+            verbose: bool = False,
+            jobs_complete_for_logging: int = 500
     ) -> None:
         """
         Move or copy multiple files in parallel.
@@ -323,6 +334,7 @@ class GCPCloudFunctions:
             workers (int): Number of worker threads.
             max_retries (int): Maximum number of retries.
             verbose (bool, optional): Whether to log each job's success. Defaults to False.
+            jobs_complete_for_logging (int, optional): The number of jobs to complete before logging. Defaults to 500.
 
         Raises:
             Exception: If the action is not 'move' or 'copy'.
@@ -347,5 +359,6 @@ class GCPCloudFunctions:
             max_retries=max_retries,
             fail_on_error=True,
             verbose=verbose,
-            collect_output=False
+            collect_output=False,
+            jobs_complete_for_logging=jobs_complete_for_logging
         )

--- a/python/utils/thread_pool_executor_util.py
+++ b/python/utils/thread_pool_executor_util.py
@@ -39,7 +39,8 @@ class MultiThreadedJobs:
             collect_output: bool = False,
             max_retries: int = 3,
             fail_on_error: bool = True,
-            verbose: bool = False
+            verbose: bool = False,
+            jobs_complete_for_logging: int = 500
     ) -> Optional[list[Any]]:
         """
         Run jobs in parallel and allow for retries. Optionally collect outputs of the jobs.
@@ -52,6 +53,7 @@ class MultiThreadedJobs:
             max_retries (int, optional): The maximum number of retries. Defaults to 3.
             fail_on_error (bool, optional): Whether to fail on error. Defaults to True.
             verbose (bool, optional): Whether to log each job's success. Defaults to False.
+            jobs_complete_for_logging (int, optional): The number of jobs to complete before logging. Defaults to 250.
 
         Returns:
             Optional[list[Any]]: A list of job results if `collect_output` is True, otherwise None.
@@ -76,7 +78,8 @@ class MultiThreadedJobs:
                     result = future.result()
                     if result or result is None:  # Successful result or no result (for jobs that don't return anything)
                         completed_jobs += 1
-                        if completed_jobs % 100 == 0:
+                        # Log progress every `jobs_complete_for_logging` jobs
+                        if completed_jobs % jobs_complete_for_logging == 0:
                             logging.info(f"Completed {completed_jobs}/{total_jobs} jobs")
                         # Log success for each job if verbose
                         if verbose:


### PR DESCRIPTION
```
INFO: 2024-09-26 17:29:03,446 : Attempting to run validate_file_pair for a total of 2200 jobs
INFO: 2024-09-26 17:29:04,295 : Completed 100/2200 jobs
INFO: 2024-09-26 17:29:04,871 : Completed 200/2200 jobs
INFO: 2024-09-26 17:29:05,466 : Completed 300/2200 jobs
INFO: 2024-09-26 17:29:06,049 : Completed 400/2200 jobs
INFO: 2024-09-26 17:29:06,643 : Completed 500/2200 jobs
INFO: 2024-09-26 17:29:07,217 : Completed 600/2200 jobs
INFO: 2024-09-26 17:29:07,819 : Completed 700/2200 jobs
INFO: 2024-09-26 17:29:08,370 : Completed 800/2200 jobs
INFO: 2024-09-26 17:29:08,962 : Completed 900/2200 jobs
...
...
INFO: 2024-09-26 17:29:16,568 : Successfully ran 2200/2200 jobs
```
Current output of job like above.  Will now look like 
```
INFO: 2024-09-26 17:29:03,446 : Attempting to run validate_file_pair for a total of 2200 jobs
INFO: 2024-09-26 17:29:06,643 : Completed 500/2200 jobs
INFO: 2024-09-26 17:29:09,516 : Completed 1000/2200 jobs
INFO: 2024-09-26 17:29:12,431 : Completed 1500/2200 jobs
INFO: 2024-09-26 17:29:15,390 : Completed 2000/2200 jobs
INFO: 2024-09-26 17:29:16,568 : Successfully ran 2200/2200 jobs
```