### PR TITLE
POD-2272: Report on invalid Terra headers

### DIFF
--- a/python/gcp_workspace_table_to_dataset_ingest.py
+++ b/python/gcp_workspace_table_to_dataset_ingest.py
@@ -146,6 +146,10 @@ if __name__ == "__main__":
     ).run()
     # Get entity metrics for workspace
     entity_metrics = terra_workspace.get_workspace_entity_info()
+
+    for table, attributes in entity_metrics.items():
+        terra_workspace.all_valid_headers_for_tdr_conversion(table_name=table, headers=attributes["attributeNames"])
+
     # Check if dataset is selfHosted. If it isn't then getting UUIDs for files will not work
     if not dataset_info["selfHosted"] and check_if_files_already_ingested:
         logging.warning("Dataset is not selfHosted. Cannot check if files have already been ingested and use UUIDs")
@@ -156,6 +160,10 @@ if __name__ == "__main__":
 
         # Get sample metrics from Terra
         sample_metrics = terra_workspace.get_gcp_workspace_metrics(entity_type=terra_table_name, remove_dicts=True)
+        #print(sample_metrics)
+        import sys
+        sys.exit()
+
         try:
             primary_key_column_name = entity_metrics[terra_table_name]["idName"]
         except KeyError:

--- a/python/gcp_workspace_table_to_dataset_ingest.py
+++ b/python/gcp_workspace_table_to_dataset_ingest.py
@@ -148,7 +148,8 @@ if __name__ == "__main__":
     entity_metrics = terra_workspace.get_workspace_entity_info()
 
     for table, attributes in entity_metrics.items():
-        terra_workspace.all_valid_headers_for_tdr_conversion(table_name=table, headers=attributes["attributeNames"])
+        terra_workspace.validate_terra_headers_for_tdr_conversion(
+            table_name=table, headers=attributes["attributeNames"])
 
     # Check if dataset is selfHosted. If it isn't then getting UUIDs for files will not work
     if not dataset_info["selfHosted"] and check_if_files_already_ingested:

--- a/python/gcp_workspace_table_to_dataset_ingest.py
+++ b/python/gcp_workspace_table_to_dataset_ingest.py
@@ -160,10 +160,6 @@ if __name__ == "__main__":
 
         # Get sample metrics from Terra
         sample_metrics = terra_workspace.get_gcp_workspace_metrics(entity_type=terra_table_name, remove_dicts=True)
-        #print(sample_metrics)
-        import sys
-        sys.exit()
-
         try:
             primary_key_column_name = entity_metrics[terra_table_name]["idName"]
         except KeyError:

--- a/python/utils/terra_utils/terra_util.py
+++ b/python/utils/terra_utils/terra_util.py
@@ -196,7 +196,7 @@ class TerraWorkspace:
 
     @staticmethod
     def validate_terra_headers_for_tdr_conversion(table_name: str, headers: list[str]) -> None:
-        tdr_header_allowed_pattern = "^[a-zA-Z0-9][_a-zA-Z0-9]*$"
+        tdr_header_allowed_pattern = "^[a-zA-Z][_a-zA-Z0-9]*$"
         tdr_max_header_length = 63
 
         headers_containing_too_many_characters = []
@@ -215,8 +215,8 @@ class TerraWorkspace:
         characters: "{', '.join(headers_containing_too_many_characters)}". The max number of characters for a header
         allowed in TDR is {tdr_max_header_length}.\n"""
         invalid_characters_error_message = f"""The following header(s) in table "{table_name}" contain invalid
-        characters: "{', '.join(headers_contain_invalid_characters)}". TDR headers must start with a number
-        or letter, and must only contain numbers, letters, and underscore characters.\n"""
+        characters: "{', '.join(headers_contain_invalid_characters)}". TDR headers must start with letter, and must
+        only contain numbers, letters, and underscore characters.\n"""
 
         error_to_report = ""
         if headers_containing_too_many_characters:

--- a/python/utils/terra_utils/terra_util.py
+++ b/python/utils/terra_utils/terra_util.py
@@ -195,7 +195,7 @@ class TerraWorkspace:
             yield next_page.json()
 
     @staticmethod
-    def all_valid_headers_for_tdr_conversion(table_name: str, headers: list[str]) -> None:
+    def validate_terra_headers_for_tdr_conversion(table_name: str, headers: list[str]) -> None:
         tdr_header_allowed_pattern = "^[a-zA-Z0-9][_a-zA-Z0-9]*$"
         tdr_max_header_length = 63
 

--- a/python/utils/terra_utils/terra_util.py
+++ b/python/utils/terra_utils/terra_util.py
@@ -215,7 +215,7 @@ class TerraWorkspace:
         characters: "{', '.join(headers_containing_too_many_characters)}". The max number of characters for a header
         allowed in TDR is {tdr_max_header_length}.\n"""
         invalid_characters_error_message = f"""The following header(s) in table "{table_name}" contain invalid
-        characters: "{', '.join(headers_contain_invalid_characters)}". TDR headers must start with letter, and must
+        characters: "{', '.join(headers_contain_invalid_characters)}". TDR headers must start with a letter, and must
         only contain numbers, letters, and underscore characters.\n"""
 
         error_to_report = ""

--- a/python/utils/terra_utils/terra_util.py
+++ b/python/utils/terra_utils/terra_util.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from typing import Any, Optional
 from urllib.parse import urlparse
 
@@ -192,6 +193,39 @@ class TerraWorkspace:
                 params={"page": page}
             )
             yield next_page.json()
+
+    @staticmethod
+    def all_valid_headers_for_tdr_conversion(table_name: str, headers: list[str]) -> None:
+        tdr_header_allowed_pattern = "^[a-zA-Z0-9][_a-zA-Z0-9]*$"
+        tdr_max_header_length = 63
+
+        headers_containing_too_many_characters = []
+        headers_contain_invalid_characters = []
+
+        for header in headers:
+            if len(header) > tdr_max_header_length:
+                headers_containing_too_many_characters.append(header)
+            if not re.match(tdr_header_allowed_pattern, header):
+                headers_contain_invalid_characters.append(header)
+
+        base_error_message = """In order to proceed, please update the problematic header(s) in you Terra table,
+        and then re-attempt the import once all problematic header(s) have been updated to follow TDR rules for
+        header naming."""
+        too_many_characters_error_message = f"""The following header(s) in table "{table_name}" contain too many
+        characters: "{', '.join(headers_containing_too_many_characters)}". The max number of characters for a header
+        allowed in TDR is {tdr_max_header_length}.\n"""
+        invalid_characters_error_message = f"""The following header(s) in table "{table_name}" contain invalid
+        characters: "{', '.join(headers_contain_invalid_characters)}". TDR headers must start with a number
+        or letter, and must only contain numbers, letters, and underscore characters.\n"""
+
+        error_to_report = ""
+        if headers_containing_too_many_characters:
+            error_to_report += too_many_characters_error_message
+        if headers_contain_invalid_characters:
+            error_to_report += invalid_characters_error_message
+        if error_to_report:
+            error_to_report += base_error_message
+            raise ValueError(error_to_report)
 
     def get_workspace_info(self) -> dict:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pandas
 pydantic==2.9.1
 pyyaml
 humanfriendly
+responses


### PR DESCRIPTION
[POD-2272](https://broadinstitute.atlassian.net/browse/POD-2272): Report on invalid Terra headers

Logic was updated in the `gcp_workspace_table_to_dataset_ingest.py` script so that we check the Terra headers before attempting to ingest the dataset into TDR. Terra and TDR have different specifications for what is considered a valid header due to the BigQuery restrictions. If the length or content of the headers are invalid, we report on _all_ problematic headers at once so a user doesn't have to run a script multiple times and find different failures each time. 

* [Example workspace](https://app.terra.bio/#workspaces/ops-integration-billing/ns_test_datatypes/data) with invalid headers 
* Example logging: 
```commandLine
ValueError: The following header(s) in table "bad_headers" contain too many
        characters: "jasbdlaknslkamlsmdjasdjkansdkanskdnjaskdjnskdjnskdaskndlaksldsklaa". The max number of characters for a header
        allowed in TDR is 63.
The following header(s) in table "bad_headers" contain invalid
        characters: "123ABC, _starts_with_underscore, contains-dash". TDR headers must start with a letter, and must
        only contain numbers, letters, and underscore characters.
In order to proceed, please update the problematic header(s) in you Terra table,
        and then re-attempt the import once all problematic header(s) have been updated to follow TDR rules for
        header naming.
```
* Screenshot of TDR specifications for column names:
![Screenshot 2024-11-21 at 3 14 56 PM](https://github.com/user-attachments/assets/0e927c5f-d93d-4d94-950f-bd86191bc94f)



[POD-2272]: https://broadinstitute.atlassian.net/browse/POD-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ