### PR TITLE
POD-2309: Allow "leave workspace" failure to pass with indirect access 

### DIFF
--- a/python/set_up_staging_workspace_and_dataset.py
+++ b/python/set_up_staging_workspace_and_dataset.py
@@ -288,7 +288,7 @@ class RemoveAllIndividualAccess:
         logging.info(
             f"Removing {self.current_user_email} from workspace {self.terra_workspace}, dataset {self.dataset_id}, "
             f"and group {self.auth_group}")
-        self.terra_workspace.leave_workspace()
+        self.terra_workspace.leave_workspace(ignore_direct_access_error=True)
         self.tdr.remove_user_from_dataset(
             dataset_id=self.dataset_id,
             user=self.current_user_email,

--- a/python/utils/terra_utils/terra_util.py
+++ b/python/utils/terra_utils/terra_util.py
@@ -695,17 +695,29 @@ class TerraWorkspace:
             content_type="application/json"
         )
 
-    def leave_workspace(self, workspace_id: Optional[str] = None) -> None:
+    def leave_workspace(self, workspace_id: Optional[str] = None, ignore_direct_access_error: bool = False) -> None:
         """
         Leave a workspace. If workspace ID not supplied will look it up
 
         Args:
             workspace_id (Optional[str], optional): The workspace ID. Defaults to None.
+            ignore_direct_access_error (Optional[bool], optional): Whether to ignore direct access errors.
+             Defaults to False.
         """
         if not workspace_id:
             workspace_info = self.get_workspace_info()
             workspace_id = workspace_info['workspace']['workspaceId']
-        self.request_util.run_request(
+        accepted_return_code = [403] if ignore_direct_access_error else []
+        res = self.request_util.run_request(
             uri=f"{SAM_LINK}/resources/v2/workspace/{workspace_id}/leave",
-            method=DELETE
+            method=DELETE,
+            accept_return_codes=accepted_return_code
         )
+
+        if (res.status_code == 403
+                and res.json()["message"] == "You can only leave a resource that you have direct access to."
+                and ignore_direct_access_error):
+            logging.info(
+                f"Did not remove user from workspace with id '{workspace_id}' as current user does not have direct"
+                f"access to the workspace (they could be an owner on the billing project)"
+            )


### PR DESCRIPTION
[POD-2309](https://broadinstitute.atlassian.net/browse/POD-2309)

Example logging/error before: 
```
INFO: 2024-11-25 13:00:22,742 : Getting workspace info for ops-integration-billing/ns_testing_Staging
{"causes":[],"message":"You can only leave a resource that you have direct access to.","source":"sam","stackTrace":[],"statusCode":403}
INFO: 2024-11-25 13:00:23,402 : Backing off _make_request(...) for 3.9s (requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://sam.dsde-prod.broadinstitute.org/api/resources/v2/workspace/a77dc1a1-6dbe-4b77-bf08-0e8840af46d7/leave)
```

Example logging after: 
```
INFO: 2024-11-25 13:03:23,062 : Getting workspace info for ops-integration-billing/ns_testing_Staging
INFO: 2024-11-25 13:03:23,909 : Did not remove user from workspace with id 'a77dc1a1-6dbe-4b77-bf08-0e8840af46d7' as current user does not have directaccess to the workspace (they could be an owner on the billing project)
INFO: 2024-11-25 13:03:23,909 : Removing user sahakian@broadinstitute.org from dataset 48c37e3a-369f-4b2e-a528-187be03ae9c2 with policy steward
INFO: 2024-11-25 13:03:24,485 : Removed sahakian@broadinstitute.org from group AUTH_ns_testing
```