### PR TITLE
POD-2310: Remove SA from Workspace

### DIFF
--- a/python/set_up_staging_workspace_and_dataset.py
+++ b/python/set_up_staging_workspace_and_dataset.py
@@ -585,8 +585,9 @@ if __name__ == '__main__':
             terra_groups=terra_groups
         ).run()
 
-    # Remove the SA at the very end of the workflow
-    terra_workspace.update_user_acl(
-        email=data_ingest_sa,
-        access_level=NO_ACCESS
-    )
+    print(f'SA: {data_ingest_sa}')
+    # Remove OLD SA(s) at the very end of the workflow
+    for account in terra_workspace.get_workspace_acl()["acl"]:
+        if account != data_ingest_sa and account.startswith("tdr-ingest-sa"):
+            logging.info(f"Removing old service account from workspace: {account}")
+            terra_workspace.update_user_acl(email=account, access_level=NO_ACCESS)

--- a/python/set_up_staging_workspace_and_dataset.py
+++ b/python/set_up_staging_workspace_and_dataset.py
@@ -585,7 +585,6 @@ if __name__ == '__main__':
             terra_groups=terra_groups
         ).run()
 
-    print(f'SA: {data_ingest_sa}')
     # Remove OLD SA(s) at the very end of the workflow
     for account in terra_workspace.get_workspace_acl()["acl"]:
         if account != data_ingest_sa and account.startswith("tdr-ingest-sa"):

--- a/python/set_up_staging_workspace_and_dataset.py
+++ b/python/set_up_staging_workspace_and_dataset.py
@@ -19,6 +19,7 @@ logging.basicConfig(
 OWNER = "OWNER"
 WRITER = "WRITER"
 READER = "READER"
+NO_ACCESS = "NO ACCESS"
 
 # Define the relative path to the file
 STAGING_WORKSPACE_DESCRIPTION_FILE = "../general_markdown/staging_workspace_description.md"
@@ -583,3 +584,10 @@ if __name__ == '__main__':
             dataset_id=dataset_id,
             terra_groups=terra_groups
         ).run()
+
+    print(f'SA: {data_ingest_sa}')
+    # Remove the SA at the very end
+    terra_workspace.update_user_acl(
+        email=data_ingest_sa,
+        access_level=NO_ACCESS
+    )

--- a/python/set_up_staging_workspace_and_dataset.py
+++ b/python/set_up_staging_workspace_and_dataset.py
@@ -585,8 +585,7 @@ if __name__ == '__main__':
             terra_groups=terra_groups
         ).run()
 
-    print(f'SA: {data_ingest_sa}')
-    # Remove the SA at the very end
+    # Remove the SA at the very end of the workflow
     terra_workspace.update_user_acl(
         email=data_ingest_sa,
         access_level=NO_ACCESS


### PR DESCRIPTION
[POD-2310](https://broadinstitute.atlassian.net/browse/POD-2310)

Example workspace: https://app.terra.bio/#workspaces/ops-integration-billing/ns_testing_2_Staging

Example logging showing removal of old SA: 
```
INFO: 2024-11-26 10:49:36,376 : Removing access for the service account associated with the OLD dataset from workspace: 'tdr-ingest-sa@datarepo-62ea4fa9.iam.gserviceaccount.com'
INFO: 2024-11-26 10:49:36,376 : Updating user tdr-ingest-sa@datarepo-62ea4fa9.iam.gserviceaccount.com to NO ACCESS in workspace ops-integration-billing/ns_testing_2_Staging
```

[POD-2310]: https://broadinstitute.atlassian.net/browse/POD-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ