### PR TITLE
POD-2304: Handle mypy for tests 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
             --ignore-missing-imports,
             --python-version=3.11
         ]
+        exclude: "^python/tests/"
         additional_dependencies: [
             "types-requests",
             "types-python-dateutil",

--- a/python/tests/integration_tests/test_google_utils.py
+++ b/python/tests/integration_tests/test_google_utils.py
@@ -2,7 +2,6 @@ import pytest
 import json
 import pathlib
 
-
 from python.utils.gcp_utils import GCPCloudFunctions
 from google.cloud import storage
 from google.auth import default
@@ -15,7 +14,7 @@ def gcp_test_resource_json():
 
 
 def check_cloud_paths(path_dicts):
-    def gcs_client() -> storage.Client:
+    def gcs_client():
         credentials, project = default()
         return storage.Client(credentials=credentials, project=project)
 
@@ -29,9 +28,6 @@ def check_cloud_paths(path_dicts):
 
 @pytest.fixture(scope='session', autouse=True)
 def setup_test_gcs_resources():
-
-    # def gen_rand_str() -> str:
-    #    return ''.join(random.choices(string.ascii_lowercase + string.digits, k=30))
 
     def gcp_test_resource_json():
         resource_json = pathlib.Path(__file__).parent.joinpath("gcp_resources.json")

--- a/python/tests/integration_tests/test_google_utils.py
+++ b/python/tests/integration_tests/test_google_utils.py
@@ -9,7 +9,7 @@ from google.cloud import storage
 from google.auth import default
 
 
-def gcp_test_resource_json() -> dict:
+def gcp_test_resource_json():
     resource_json = pathlib.Path(__file__).parent.joinpath("gcp_resources.json")
     json_data = json.loads(resource_json.read_text())
     return json_data

--- a/python/tests/integration_tests/test_google_utils.py
+++ b/python/tests/integration_tests/test_google_utils.py
@@ -1,7 +1,6 @@
 import pytest
 import json
 import pathlib
-from typing import Any
 
 
 from python.utils.gcp_utils import GCPCloudFunctions
@@ -15,7 +14,7 @@ def gcp_test_resource_json():
     return json_data
 
 
-def check_cloud_paths(path_dicts: list[dict]) -> None:
+def check_cloud_paths(path_dicts):
     def gcs_client() -> storage.Client:
         credentials, project = default()
         return storage.Client(credentials=credentials, project=project)
@@ -29,25 +28,25 @@ def check_cloud_paths(path_dicts: list[dict]) -> None:
 
 
 @pytest.fixture(scope='session', autouse=True)
-def setup_test_gcs_resources() -> Any:
+def setup_test_gcs_resources():
 
     # def gen_rand_str() -> str:
     #    return ''.join(random.choices(string.ascii_lowercase + string.digits, k=30))
 
-    def gcp_test_resource_json() -> dict:
+    def gcp_test_resource_json():
         resource_json = pathlib.Path(__file__).parent.joinpath("gcp_resources.json")
         json_data = json.loads(resource_json.read_text())
         return json_data
 
-    def gcs_client() -> storage.Client:
+    def gcs_client():
         credentials, project = default()
         return storage.Client(credentials=credentials, project=project)
 
-    def del_bucket_objs(obj_list: list) -> None:
+    def del_bucket_objs(obj_list):
         for item in obj_list:
             item.delete()
 
-    def create_cloud_files() -> None:
+    def create_cloud_files():
 
         bucket = client.bucket(json_data["bucket"])
         for test, test_info in json_data["tests"].items():
@@ -59,7 +58,7 @@ def setup_test_gcs_resources() -> Any:
     client = gcs_client()
     json_data = gcp_test_resource_json()
     test_bucket = client.bucket(json_data["bucket"])
-    # cleanup bucket if any left over objects are present before creating new ones
+    # cleanup bucket if any left-over objects are present before creating new ones
     blob_list = test_bucket.list_blobs()
     if blob_list.num_results > 0:
         del_bucket_objs(obj_list=blob_list)
@@ -74,7 +73,7 @@ def setup_test_gcs_resources() -> Any:
     del_bucket_objs(blob_list)
 
 
-def test_list_bucket_contents() -> None:
+def test_list_bucket_contents():
     resources = gcp_test_resource_json()['tests']
     expected_files = []
     gcp_blob_count = 0
@@ -100,13 +99,13 @@ def test_list_bucket_contents() -> None:
     assert len(found_files) == gcp_blob_count, f"Expected {gcp_blob_count} files, got {len(found_files)}. {message}"
 
 
-def test_get_blob_details() -> None:
+def test_get_blob_details():
     test_data = gcp_test_resource_json()['tests']['get_blob_details']['test_data']
     result = GCPCloudFunctions().load_blob_from_full_path(full_path=test_data['function_input']['blob_path'])
     assert result.path == "/b/ops_dev_bucket/o/list_bucket_test%2Fex_file_1.txt"
 
 
-def test_copy_cloud_file() -> None:
+def test_copy_cloud_file():
     test_data = gcp_test_resource_json()['tests']['copy_file']['test_data']
     validations = test_data['validation']
 
@@ -118,7 +117,7 @@ def test_copy_cloud_file() -> None:
         assert item["check_passed"], "Files were not in expected end state"
 
 
-def test_delete_cloud_file() -> None:
+def test_delete_cloud_file():
     test_data = gcp_test_resource_json()['tests']['delete_file']['test_data']
     validations = test_data['validation']
 
@@ -128,7 +127,7 @@ def test_delete_cloud_file() -> None:
         assert item["check_passed"], "Files were not in expected end state"
 
 
-def test_move_cloud_file() -> None:
+def test_move_cloud_file():
     test_data = gcp_test_resource_json()['tests']['move_file']['test_data']
     validations = test_data['validation']
 
@@ -140,14 +139,14 @@ def test_move_cloud_file() -> None:
         assert item["check_passed"], "Files were not in expected end state"
 
 
-def test_get_filesize() -> None:
+def test_get_filesize():
     test_data = gcp_test_resource_json()['tests']['get_filesize']['test_data']
 
     filesize = GCPCloudFunctions().get_filesize(target_path=test_data['function_input']['source_path'])
     assert filesize == 30, "Filesize was not as expected"
 
 
-def test_validate_files_are_same() -> None:
+def test_validate_files_are_same():
     test_data = gcp_test_resource_json()['tests']['validate_files_are_same']['test_data']
 
     files_match = GCPCloudFunctions().validate_files_are_same(
@@ -157,7 +156,7 @@ def test_validate_files_are_same() -> None:
     assert files_match and not files_do_not_match, "File validations did not return expected results"
 
 
-def test_delete_multiple_files() -> None:
+def test_delete_multiple_files():
     test_data = gcp_test_resource_json()['tests']['delete_multiple_files']['test_data']
     validations = test_data['validation']
 
@@ -167,7 +166,7 @@ def test_delete_multiple_files() -> None:
         assert item["check_passed"], "Files were not in expected end state"
 
 
-def test_validate_file_pair() -> None:
+def test_validate_file_pair():
     test_data = gcp_test_resource_json()['tests']['validate_file_pair']['test_data']
 
     files_match = GCPCloudFunctions().validate_file_pair(
@@ -180,7 +179,7 @@ def test_validate_file_pair() -> None:
         "File validations did not return expected results"
 
 
-def test_loop_and_log_validation_files_multithreaded() -> None:
+def test_loop_and_log_validation_files_multithreaded():
     test_data = gcp_test_resource_json()['tests']['loop_and_log_validation_files_multithreaded']['test_data']
 
     result = GCPCloudFunctions().loop_and_log_validation_files_multithreaded(
@@ -189,7 +188,7 @@ def test_loop_and_log_validation_files_multithreaded() -> None:
     assert len(result) == 1, "Expected one file to be different, got more or less"
 
 
-def test_multithread_copy_of_files_with_validation() -> None:
+def test_multithread_copy_of_files_with_validation():
     test_data = gcp_test_resource_json()['tests']['multithread_copy_of_files_with_validation']['test_data']
     validation = test_data['validation']
 
@@ -200,11 +199,11 @@ def test_multithread_copy_of_files_with_validation() -> None:
         assert item["check_passed"], "Files were not in expected end state"
 
 
-def test_move_or_copy_multiple_files() -> None:
+def test_move_or_copy_multiple_files():
     test_data = gcp_test_resource_json()['tests']['move_or_copy_multiple_files']['test_data']
     validation = test_data['validation']
 
-    def run_copy_test() -> None:
+    def run_copy_test():
 
         GCPCloudFunctions().move_or_copy_multiple_files(
             files_to_move=test_data['function_input']['copy_test_input'], action="copy", workers=2, max_retries=1)
@@ -212,7 +211,7 @@ def test_move_or_copy_multiple_files() -> None:
         for item in validation['copy_test']:
             assert item["check_passed"], "Files were not in expected end state"
 
-    def run_mv_test() -> None:
+    def run_mv_test():
 
         GCPCloudFunctions().move_or_copy_multiple_files(
             files_to_move=test_data['function_input']['move_test_input'], action="move", workers=2, max_retries=1)

--- a/python/tests/integration_tests/test_terra_util.py
+++ b/python/tests/integration_tests/test_terra_util.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 import os
 import re
-from typing import Any
 
 from python.utils import GCP
 from python.utils.request_util import RunRequest

--- a/python/tests/integration_tests/test_terra_util.py
+++ b/python/tests/integration_tests/test_terra_util.py
@@ -26,7 +26,7 @@ terra_groups = TerraGroups(request_util=request_util)
 
 
 @pytest.fixture(scope="session", autouse=True)
-def setup_test_terra_resources() -> Any:
+def setup_test_terra_resources():
     # Attempt to delete the test workspace before starting any tests
     try:
         terra_workspace.delete_workspace()
@@ -43,7 +43,7 @@ def setup_test_terra_resources() -> Any:
     yield
 
 
-def test_get_workspace_acl() -> None:
+def test_get_workspace_acl():
     res = terra_workspace.get_workspace_acl()
     for _, perms in res["acl"].items():
         assert perms["accessLevel"] == "OWNER"
@@ -51,7 +51,7 @@ def test_get_workspace_acl() -> None:
         assert perms["canShare"] is True
 
 
-def test_get_workspace_info() -> None:
+def test_get_workspace_info():
     bucket = terra_workspace.get_workspace_bucket()
     res = terra_workspace.get_workspace_info()
     assert res["workspace"]["attributes"] == {}
@@ -65,7 +65,7 @@ def test_get_workspace_info() -> None:
     assert res["canCompute"] is True
 
 
-def test_update_user_acl() -> None:
+def test_update_user_acl():
     access_level = "READER"
     email = "test@broadinstitute.org"
     res = terra_workspace.update_user_acl(
@@ -79,7 +79,7 @@ def test_update_user_acl() -> None:
     assert res["usersUpdated"][0]["email"] == email
 
 
-def test_put_metadata_for_library_dataset() -> None:
+def test_put_metadata_for_library_dataset():
     bucket = terra_workspace.get_workspace_bucket()
     library_metadata = {"library:dulvn": 1}
     res = terra_workspace.put_metadata_for_library_dataset(library_metadata=library_metadata)
@@ -91,7 +91,7 @@ def test_put_metadata_for_library_dataset() -> None:
     assert res["namespace"] == INTEGRATION_TEST_TERRA_BILLING_PROJECT
 
 
-def test_update_multiple_users_acl() -> None:
+def test_update_multiple_users_acl():
     acl_list = [
         {
             "email": "test2@broadinstitute.org",
@@ -120,24 +120,24 @@ def test_update_multiple_users_acl() -> None:
             assert invite["canShare"] is True
 
 
-def test_create_workspace_attributes_ingest_dict() -> None:
+def test_create_workspace_attributes_ingest_dict():
     res = terra_workspace.create_workspace_attributes_ingest_dict()
     assert res == [{"attribute": "library:dulvn", "value": "1"}]
 
 
-def test_upload_metadata_to_workspace_table() -> None:
+def test_upload_metadata_to_workspace_table():
     current_dir = os.path.dirname(__file__)
     file_path = os.path.join(current_dir, "sample.tsv")
     res = terra_workspace.upload_metadata_to_workspace_table(entities_tsv=file_path)
     assert res == "sample"
 
 
-def test_get_workspace_workflows() -> None:
+def test_get_workspace_workflows():
     res = terra_workspace.get_workspace_workflows()
     assert res == []
 
 
-def test_import_workflow() -> None:
+def test_import_workflow():
     workflow_name = "ExportDataFromSnapshotToOutputBucket"
     status_code = WorkflowConfigs(
         workflow_name=workflow_name,
@@ -147,37 +147,37 @@ def test_import_workflow() -> None:
     assert status_code == 201
 
 
-def test_get_gcp_workspace_metrics() -> None:
+def test_get_gcp_workspace_metrics():
     res = terra_workspace.get_gcp_workspace_metrics(entity_type="sample")
     expected_res = [{"attributes": {"sample_alias": "ABC"}, "entityType": "sample", "name": "RP-123_ABC"}]
     assert res == expected_res
 
 
-def test_get_workspace_entity_info() -> None:
+def test_get_workspace_entity_info():
     res = terra_workspace.get_workspace_entity_info()
     expected_res = {"sample": {"attributeNames": ["sample_alias"], "count": 1, "idName": "sample_id"}}
     assert res == expected_res
 
 
-def test_create_group() -> None:
+def test_create_group():
     res = terra_groups.create_group(group_name=INTEGRATION_TEST_GROUP_NAME)
     assert res == 201
 
 
-def test_add_user_to_group() -> None:
+def test_add_user_to_group():
     res = terra_groups.add_user_to_group(
         group=INTEGRATION_TEST_GROUP_NAME, email="test@broadinstitute.org", role=MEMBER,
     )
     assert res == 204
 
 
-def test_remove_user_from_group() -> None:
+def test_remove_user_from_group():
     res = terra_groups.remove_user_from_group(
         group=INTEGRATION_TEST_GROUP_NAME, email="test@broadinstitute.org", role=MEMBER
     )
     assert res == 204
 
 
-def test_check_role() -> None:
+def test_check_role():
     with pytest.raises(ValueError, match=re.escape(f"Role must be one of {terra_groups.GROUP_MEMBERSHIP_OPTIONS}")):
         terra_groups._check_role(role="members")

--- a/python/tests/unit_tests/test_tdr_utils.py
+++ b/python/tests/unit_tests/test_tdr_utils.py
@@ -1,7 +1,6 @@
 import pytest
 import json
 import pathlib
-from typing import Any
 import responses
 from responses import matchers
 
@@ -41,14 +40,14 @@ def mock_api_response(test_json):
 
 
 @pytest.fixture()
-def tdr_test_resource_json() -> dict:
+def tdr_test_resource_json():
     resource_json = pathlib.Path(__file__).parent.joinpath("tdr_resources.json")
     json_data = json.loads(resource_json.read_text())
     return json_data
 
 
 @pytest.fixture()
-def tdr_client() -> Any:
+def tdr_client():
     token = Token(cloud='gcp')
     requestclient = RunRequest(token, max_retries=1, max_backoff_time=1)
     return TDR(request_util=requestclient)
@@ -57,12 +56,12 @@ def tdr_client() -> Any:
 class TestGetUtils:
 
     @pytest.fixture(autouse=True)
-    def _get_tdr_client(self, tdr_client: Any, tdr_test_resource_json: Any) -> None:
+    def _get_tdr_client(self, tdr_client, tdr_test_resource_json):
         self.tdr_client = tdr_client
         self.test_info = tdr_test_resource_json
 
     @responses.activate
-    def test_get_data_set_files(self) -> None:
+    def test_get_data_set_files(self):
         test_data = self.test_info['tests']['get_files_endpoint']
         mock_api_response(test_json=test_data['mock_response']['page_one'])
         mock_api_response(test_json=test_data['mock_response']['page_two'])
@@ -70,7 +69,7 @@ class TestGetUtils:
         assert len(file_list) == 3
 
     @responses.activate
-    def test_create_file_dict(self) -> None:
+    def test_create_file_dict(self):
         test_data = self.test_info['tests']['get_files_endpoint']
         mock_api_response(test_json=test_data['mock_response']['page_one'])
         mock_api_response(test_json=test_data['mock_response']['page_two'])
@@ -78,14 +77,14 @@ class TestGetUtils:
         assert len(file_dict.keys()) == 3
 
     @responses.activate
-    def test_get_snapshot_info(self) -> None:
+    def test_get_snapshot_info(self):
         test_data = self.test_info['tests']['get_snapshot_endpoint']
         mock_api_response(test_json=test_data['mock_response'])
         cmd = self.tdr_client.get_snapshot_info(snapshot_id=test_data['function_input'])
         assert cmd['name'] == 'snapshot name'
 
     @responses.activate
-    def test_check_if_dataset_exists(self) -> None:
+    def test_check_if_dataset_exists(self):
         test_data = self.test_info['tests']['list_datasets_endpoint']
         mock_api_response(test_json=test_data['mock_response']['page_one'])
         mock_api_response(test_json=test_data['mock_response']['page_two'])
@@ -95,14 +94,14 @@ class TestGetUtils:
         assert dataset_exists
 
     @responses.activate
-    def test_get_dataset_info(self) -> None:
+    def test_get_dataset_info(self):
         test_data = self.test_info['tests']['get_dataset_endpoint']
         mock_api_response(test_json=test_data['mock_response'])
         found_dataset = self.tdr_client.get_dataset_info(dataset_id=test_data['function_input']['dataset_id'])
         assert found_dataset
 
     @responses.activate
-    def test_get_table_schema_info(self) -> None:
+    def test_get_table_schema_info(self):
         test_data = self.test_info['tests']['get_dataset_endpoint']
         mock_api_response(test_json=test_data['mock_response'])
         schema_info = self.tdr_client.get_table_schema_info(
@@ -110,7 +109,7 @@ class TestGetUtils:
         assert schema_info
 
     @responses.activate
-    def test_get_data_set_table_metrics(self) -> None:
+    def test_get_data_set_table_metrics(self):
         test_data = self.test_info['tests']['get_dataset_table']
         mock_api_response(test_json=test_data['mock_response']['page_one'])
         mock_api_response(test_json=test_data['mock_response']['page_two'])
@@ -120,7 +119,7 @@ class TestGetUtils:
         assert table_metrics
 
     @responses.activate
-    def test_get_data_set_sample_ids(self) -> None:
+    def test_get_data_set_sample_ids(self):
         test_data = self.test_info['tests']['get_dataset_table']
         mock_api_response(test_json=test_data['mock_response']['page_one'])
         mock_api_response(test_json=test_data['mock_response']['page_two'])
@@ -132,7 +131,7 @@ class TestGetUtils:
         assert sample_ids
 
     @responses.activate
-    def test_get_files_from_snapshot(self) -> None:
+    def test_get_files_from_snapshot(self):
         test_data = self.test_info['tests']['get_snapshot_files']
         mock_api_response(test_json=test_data['mock_response']['page_one'])
         mock_api_response(test_json=test_data['mock_response']['page_two'])
@@ -140,7 +139,7 @@ class TestGetUtils:
         assert snapshot_files
 
     @responses.activate
-    def test_InferTDRSchema(self) -> None:
+    def test_InferTDRSchema(self):
         # input_metadata: list[dict], table_name
         test_data = self.test_info['tests']['InferTDRSchema']
         cmd = InferTDRSchema(input_metadata=test_data['function_input']['input_metadata'],
@@ -151,12 +150,12 @@ class TestGetUtils:
 class TestCreateUtils:
 
     @pytest.fixture(autouse=True)
-    def _get_tdr_client(self, tdr_client: Any, tdr_test_resource_json: Any) -> None:
+    def _get_tdr_client(self, tdr_client, tdr_test_resource_json):
         self.tdr_client = tdr_client
         self.test_info = tdr_test_resource_json
 
     @responses.activate
-    def test_get_or_create_dataset(self) -> None:
+    def test_get_or_create_dataset(self):
         list_dataset_endpoint = self.test_info['tests']['list_datasets_endpoint']
         create_dataset_endpoint = self.test_info['tests']['create_dataset_endpoint']
         get_job_status = self.test_info['tests']['get_job_status']
@@ -177,7 +176,7 @@ class TestCreateUtils:
         # Get job results
         mock_api_response(test_json=get_job_results['mock_response'])
 
-        def get_existing_dataset() -> None:
+        def get_existing_dataset():
             cmd = self.tdr_client.get_or_create_dataset(
                 dataset_name=create_dataset_endpoint['function_input']['dataset_name'],
                 billing_profile=create_dataset_endpoint['function_input']['billing_profile'],
@@ -188,7 +187,7 @@ class TestCreateUtils:
             )
             assert cmd == 'ex_dataset_name_guid'
 
-        def create_new_dataset() -> None:
+        def create_new_dataset():
             new_dataset = self.tdr_client.get_or_create_dataset(
                 dataset_name=create_dataset_endpoint['function_input']['new_dataset_name'],
                 billing_profile=create_dataset_endpoint['function_input']['billing_profile'],
@@ -202,7 +201,7 @@ class TestCreateUtils:
         create_new_dataset()
 
     @responses.activate
-    def test_add_user_to_dataset(self) -> None:
+    def test_add_user_to_dataset(self):
         test_data = self.test_info['tests']['test_add_user_to_dataset']
         mock_api_response(test_json=test_data['mock_response'])
         self.tdr_client.add_user_to_dataset(
@@ -211,7 +210,7 @@ class TestCreateUtils:
             policy=test_data['function_input']['policy'])
 
     @responses.activate
-    def test_update_dataset_schema(self) -> None:
+    def test_update_dataset_schema(self):
         test_data = self.test_info['tests']['test_update_dataset_schema']
         mock_api_response(test_json=test_data['mock_response']['update_schema'])
         mock_api_response(self.test_info['tests']['get_job_status']['mock_response'])
@@ -224,7 +223,7 @@ class TestCreateUtils:
         )
 
     @responses.activate
-    def test_batch_ingest_to_dataset(self) -> None:
+    def test_batch_ingest_to_dataset(self):
         test_data = self.test_info['tests']['test_batch_ingest']['metadata_ingest']
         mock_api_response(test_json=test_data['mock_response']['dataset_ingest'])
         mock_api_response(self.test_info['tests']['get_job_status']['mock_response'])
@@ -240,7 +239,7 @@ class TestCreateUtils:
         ).run()
 
     @responses.activate
-    def test_ingest_files(self) -> None:
+    def test_ingest_files(self):
         test_data = self.test_info['tests']['test_batch_ingest']['file_ingest']
         mock_api_response(test_json=test_data['mock_response']['file_ingest'])
         mock_api_response(self.test_info['tests']['get_job_status']['mock_response'])
@@ -254,12 +253,12 @@ class TestCreateUtils:
 class TestDeleteUtils:
 
     @pytest.fixture(autouse=True)
-    def _get_tdr_client(self, tdr_client: Any, tdr_test_resource_json: Any) -> None:
+    def _get_tdr_client(self, tdr_client, tdr_test_resource_json):
         self.tdr_client = tdr_client
         self.test_info = tdr_test_resource_json
 
     @responses.activate
-    def test_delete_files(self) -> None:
+    def test_delete_files(self):
         test_data = self.test_info['tests']['delete_files_endpoint']
         mock_api_response(test_json=test_data['mock_response']['delete_file'])
         mock_api_response(self.test_info['tests']['get_job_status']['mock_response'])
@@ -268,7 +267,7 @@ class TestDeleteUtils:
                                      dataset_id=test_data['function_input']['dataset_id'])
 
     @responses.activate
-    def test_delete_snapshot(self) -> None:
+    def test_delete_snapshot(self):
         test_data = self.test_info['tests']['test_delete_snapshot']
         mock_api_response(test_data['mock_response']['delete_snapshot'])
         mock_api_response(self.test_info['tests']['get_job_status']['mock_response'])
@@ -276,7 +275,7 @@ class TestDeleteUtils:
         self.tdr_client.delete_snapshot(snapshot_id=test_data['function_input']['snapshot_guid'])
 
     @responses.activate
-    def test_delete_dataset(self) -> None:
+    def test_delete_dataset(self):
         test_data = self.test_info['tests']['test_delete_dataset']
         mock_api_response(test_data['mock_response']['delete_dataset'])
         mock_api_response(self.test_info['tests']['get_job_status']['mock_response'])


### PR DESCRIPTION
[POD-2304](https://broadinstitute.atlassian.net/browse/POD-2304): Handle mypy for tests 

Changes include: Updating `.pre-commit-config.yaml` to configure mypy to ignore anything in the `tests` subdirectory and removing existing type annotations from the test files.

_Screenshot showing mypy check was ignored:_
<img width="647" alt="Screenshot 2024-12-02 at 10 52 22 AM" src="https://github.com/user-attachments/assets/66c62f8b-5664-4706-8a42-d9be04582c47">


[POD-2304]: https://broadinstitute.atlassian.net/browse/POD-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ