### PR TITLE
Parse known args only

### DIFF
--- a/python/add_public_cloud_reference.py
+++ b/python/add_public_cloud_reference.py
@@ -161,7 +161,8 @@ def get_args() -> argparse.Namespace:
         help="The path to the bra-mem tar file README file"
     )
 
-    return parser.parse_args()
+    known_args, _ = parser.parse_known_args()
+    return known_args
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes were made to parse only the known args. The change was required because the admin job now contains the `created_at` and `requester` fields, which should be ignored when passing the parameters to the python script/Cloud Function. 