### PR TITLE
POD-2481: Move reheadering workflow from horsefish to ops-terra-utils

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -153,3 +153,17 @@ workflows:
     readMePath: /wdl/AzDatasetToGcp/README.md
     testParameterFiles:
       - /wdl/AzDatasetToGcp/AzDatasetToGcp.wdl
+
+  - name: ReheaderCram
+    subclass: WDL
+    primaryDescriptorPath: /wdl/ReheaderCram/ReheaderCram.wdl
+    readMePath: /wdl/ReheaderCram/README.md
+    testParameterFiles:
+      - /wdl/ReheaderCram/ReheaderCram.wdl
+
+  - name: ReheaderBam
+    subclass: WDL
+    primaryDescriptorPath: /wdl/ReheaderBam/ReheaderBam.wdl
+    readMePath: /wdl/ReheaderBam/README.md
+    testParameterFiles:
+      - /wdl/ReheaderBam/ReheaderBam.wdl

--- a/wdl/ReheaderBam/README.md
+++ b/wdl/ReheaderBam/README.md
@@ -1,0 +1,20 @@
+# WDL Input Overview
+
+This WDL script re-headers a BAM file using samtools. This can be used when a sample name has changed, and the BAM
+header needs to be updated to replace the old sample alias with the new sample alias.
+
+## Inputs Table:
+| Input Name           | Description                                                                            | Type   | Required | Default  |
+|----------------------|----------------------------------------------------------------------------------------|--------|----------|----------|
+| **input_bam**        | The path to the original BAM file.                                                     | File   | Yes      | N/A      |
+| **old_sample**       | The OLD sample alias.                                                                  | String | Yes      | N/A      |
+| **new_sample**       | The NEW sample alias.                                                                  | String | Yes      | N/A      |
+| **ref_fasta**        | The path to the fasta file corresponding to the reference that the file is aligned to. | File   | Yes      | N/A      |
+| **ref_fasta_index**  | The path to the fasta file index.                                                      | File   | Yes      | N/A      |
+
+## Outputs Table:
+| Output Name                 | Description                                              | Type |
+|-----------------------------|----------------------------------------------------------|------|
+| **reheadered_bam_path**     | The path to the new re-headered bam                      | File |
+| **reheadered_bai_path**     | The path to the new bai file associated with the new bam | File |
+| **reheadered_bam_md5_path** | The path to the new md5 file associated with the new bam | File |

--- a/wdl/ReheaderBam/README.md
+++ b/wdl/ReheaderBam/README.md
@@ -4,13 +4,13 @@ This WDL script re-headers a BAM file using samtools. This can be used when a sa
 header needs to be updated to replace the old sample alias with the new sample alias.
 
 ## Inputs Table:
-| Input Name           | Description                                                                            | Type   | Required | Default  |
-|----------------------|----------------------------------------------------------------------------------------|--------|----------|----------|
-| **input_bam**        | The path to the original BAM file.                                                     | File   | Yes      | N/A      |
-| **old_sample**       | The OLD sample alias.                                                                  | String | Yes      | N/A      |
-| **new_sample**       | The NEW sample alias.                                                                  | String | Yes      | N/A      |
-| **ref_fasta**        | The path to the fasta file corresponding to the reference that the file is aligned to. | File   | Yes      | N/A      |
-| **ref_fasta_index**  | The path to the fasta file index.                                                      | File   | Yes      | N/A      |
+| Input Name           | Description                                                                                                                                                                      | Type   | Required | Default  |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|----------|----------|
+| **input_bam**        | The path to the original BAM file.                                                                                                                                               | File   | Yes      | N/A      |
+| **old_sample**       | The OLD sample alias.                                                                                                                                                            | String | Yes      | N/A      |
+| **new_sample**       | The NEW sample alias.                                                                                                                                                            | String | Yes      | N/A      |
+| **ref_fasta**        | The path to the fasta file corresponding to the reference that the file is aligned to. Not required, but helps in making the indexing of the new file go faster/cost less money. | File   | No       | N/A      |
+| **ref_fasta_index**  | The path to the fasta file index. Not required, but should be provided if the `ref_fasta` is provided.                                                                           | File   | No       | N/A      |
 
 ## Outputs Table:
 | Output Name                 | Description                                              | Type |

--- a/wdl/ReheaderBam/ReheaderBam.wdl
+++ b/wdl/ReheaderBam/ReheaderBam.wdl
@@ -82,7 +82,7 @@ task ReheaderFile {
     # Output files from the task
     output {
         File new_bam = "~{new_bam}"
-        File new_baii = "~{new_bai}"
+        File new_bai = "~{new_bai}"
         File new_md5 = "~{new_md5}"
     }
 }

--- a/wdl/ReheaderBam/ReheaderBam.wdl
+++ b/wdl/ReheaderBam/ReheaderBam.wdl
@@ -1,0 +1,88 @@
+version 1.0
+
+# Workflow for reheadering a BAM file.
+# The workflow takes an input BAM file, a reference genome, and changes the sample name in the BAM header.
+workflow ReaheaderBam {
+    input {
+        File input_bam          # Input BAM file to be reheadered
+        String old_sample       # Original sample name in the BAM file
+        String new_sample       # New sample name to replace the original
+        File ref_fasta          # Reference genome fasta file
+        File ref_fasta_index    # Index for the reference genome fasta file
+    }
+
+    # Main task call to perform reheadering
+    call ReheaderFile {
+        input:
+            input_bam = input_bam,
+            old_sample = old_sample,
+            new_sample = new_sample,
+            ref_fasta = ref_fasta,
+            ref_fasta_index = ref_fasta_index,
+    }
+
+    # Output of the workflow includes the new BAM file, its index, and MD5 checksum.
+    output {
+        File bam_path = ReheaderFile.new_bam
+        File bai_path = ReheaderFile.new_bai
+        File md5_path = ReheaderFile.new_md5
+    }
+}
+
+# Task definition for reheadering a BAM file.
+task ReheaderFile {
+    input {
+        File input_bam          # Input BAM file to be reheadered
+        String old_sample       # Original sample name in the BAM file
+        String new_sample       # New sample name to replace the original
+        File ref_fasta          # Reference genome fasta file
+        File ref_fasta_index    # Index for the reference genome fasta file
+    }
+
+    # Naming convention for new files
+    String new_bam = new_sample + ".bam"
+    String new_bai = new_sample + ".bai"
+    String new_md5 = new_sample + ".bam.md5"
+
+    # Calculate the required disk size based on input file sizes
+    Int disk_size = ceil((2 * size(input_bam, "GiB")) + size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB")) + 20
+
+    command {
+        set -e
+
+        # Extract header from BAM, modify sample name, and remove @PG lines
+        samtools view -H ~{input_bam} > header
+        sed --expression='s/SM:~{old_sample}/SM:~{new_sample}/g' header > remapped_header
+        grep -v '^@PG' remapped_header > updated_header
+
+        # Reheader the BAM file with updated header
+        samtools reheader -P updated_header ~{input_bam} > ~{new_bam}
+
+        # Generate MD5 checksum for the new BAM file
+        md5sum ~{new_bam} > ~{new_md5}
+
+        # Prepare REF_CACHE for indexing the BAM file
+        seq_cache_populate.pl -root ./ref/cache ~{ref_fasta}
+        export REF_PATH=:
+        export REF_CACHE=./ref/cache/%2s/%2s/%s
+
+        # Index the new BAM file
+        samtools index ~{new_bam} > ~{new_bai}
+    }
+
+    # Runtime parameters including docker image, memory, CPU, disk, and retries
+    runtime {
+        docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
+        preemptible: 3
+        memory: "7 GiB"
+        cpu: "1"
+        disks: "local-disk " + disk_size + " HDD"
+    }
+
+    # Output files from the task
+    output {
+        File new_bam = "~{new_bam}"
+        File new_baii = "~{new_bai}"
+        File new_md5 = "~{new_md5}"
+    }
+}

--- a/wdl/ReheaderBam/ReheaderBam.wdl
+++ b/wdl/ReheaderBam/ReheaderBam.wdl
@@ -23,9 +23,9 @@ workflow ReaheaderBam {
 
     # Output of the workflow includes the new BAM file, its index, and MD5 checksum.
     output {
-        File bam_path = ReheaderFile.new_bam
-        File bai_path = ReheaderFile.new_bai
-        File md5_path = ReheaderFile.new_md5
+        File reheadered_bam_path = ReheaderFile.new_bam
+        File reheadered_bai_path = ReheaderFile.new_bai
+        File reheadered_bam_md5_path = ReheaderFile.new_md5
     }
 }
 

--- a/wdl/ReheaderCram/README.md
+++ b/wdl/ReheaderCram/README.md
@@ -4,13 +4,13 @@ This WDL script re-headers a CRAM file using samtools. This can be used when a s
 header needs to be updated to replace the old sample alias with the new sample alias.
 
 ## Inputs Table:
-| Input Name          | Description                                                                            | Type   | Required | Default  |
-|---------------------|----------------------------------------------------------------------------------------|--------|----------|----------|
-| **input_cram**      | The path to the original CRAM file.                                                    | File   | Yes      | N/A      |
-| **old_sample**      | The OLD sample alias.                                                                  | String | Yes      | N/A      |
-| **new_sample**      | The NEW sample alias.                                                                  | String | Yes      | N/A      |
-| **ref_fasta**       | The path to the fasta file corresponding to the reference that the file is aligned to. | File   | Yes      | N/A      |
-| **ref_fasta_index** | The path to the fasta file index.                                                      | File   | Yes      | N/A      |
+| Input Name          | Description                                                                                                                                                                      | Type   | Required | Default  |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|----------|----------|
+| **input_cram**      | The path to the original CRAM file.                                                                                                                                              | File   | Yes      | N/A      |
+| **old_sample**      | The OLD sample alias.                                                                                                                                                            | String | Yes      | N/A      |
+| **new_sample**      | The NEW sample alias.                                                                                                                                                            | String | Yes      | N/A      |
+| **ref_fasta**       | The path to the fasta file corresponding to the reference that the file is aligned to. Not required, but helps in making the indexing of the new file go faster/cost less money. | File   | No       | N/A      |
+| **ref_fasta_index** | The path to the fasta file index. Not required, but should be provided if the `ref_fasta` is provided.                                                                           | File   | No       | N/A      |
 
 ## Outputs Table:
 | Output Name                  | Description                                               | Type |

--- a/wdl/ReheaderCram/README.md
+++ b/wdl/ReheaderCram/README.md
@@ -1,0 +1,20 @@
+# WDL Input Overview
+
+This WDL script re-headers a CRAM file using samtools. This can be used when a sample name has changed, and the CRAM
+header needs to be updated to replace the old sample alias with the new sample alias.
+
+## Inputs Table:
+| Input Name          | Description                                                                            | Type   | Required | Default  |
+|---------------------|----------------------------------------------------------------------------------------|--------|----------|----------|
+| **input_cram**      | The path to the original CRAM file.                                                    | File   | Yes      | N/A      |
+| **old_sample**      | The OLD sample alias.                                                                  | String | Yes      | N/A      |
+| **new_sample**      | The NEW sample alias.                                                                  | String | Yes      | N/A      |
+| **ref_fasta**       | The path to the fasta file corresponding to the reference that the file is aligned to. | File   | Yes      | N/A      |
+| **ref_fasta_index** | The path to the fasta file index.                                                      | File   | Yes      | N/A      |
+
+## Outputs Table:
+| Output Name                  | Description                                               | Type |
+|------------------------------|-----------------------------------------------------------|------|
+| **reheadered_cram_path**     | The path to the new re-headered cram                      | File |
+| **reheadered_crai_path**     | The path to the new bai file associated with the new cram | File |
+| **reheadered_cram_md5_path** | The path to the new md5 file associated with the new cram | File |

--- a/wdl/ReheaderCram/ReheaderCram.wdl
+++ b/wdl/ReheaderCram/ReheaderCram.wdl
@@ -23,9 +23,9 @@ workflow ReaheaderCram {
 
     # Output of the workflow includes the new CRAM file, its index, and MD5 checksum.
     output {
-        File cram_path = ReheaderFile.new_cram
-        File crai_path = ReheaderFile.new_crai
-        File md5_path = ReheaderFile.new_md5
+        File reheadered_cram_path = ReheaderFile.new_cram
+        File reheadered_crai_path = ReheaderFile.new_crai
+        File reheadered_cram_md5_path = ReheaderFile.new_md5
     }
 }
 

--- a/wdl/ReheaderCram/ReheaderCram.wdl
+++ b/wdl/ReheaderCram/ReheaderCram.wdl
@@ -7,8 +7,8 @@ workflow ReaheaderCram {
         File input_cram         # Input CRAM file to be reheadered
         String old_sample       # Original sample name in the CRAM file
         String new_sample       # New sample name to replace the original
-        File ref_fasta          # Reference genome fasta file
-        File ref_fasta_index    # Index for the reference genome fasta file
+        File? ref_fasta          # Reference genome fasta file
+        File? ref_fasta_index    # Index for the reference genome fasta file
     }
 
     # Main task call to perform reheadering
@@ -35,8 +35,8 @@ task ReheaderFile {
         File input_cram         # Input CRAM file to be reheadered
         String old_sample       # Original sample name in the CRAM file
         String new_sample       # New sample name to replace the original
-        File ref_fasta          # Reference genome fasta file
-        File ref_fasta_index    # Index for the reference genome fasta file
+        File? ref_fasta          # Reference genome fasta file
+        File? ref_fasta_index    # Index for the reference genome fasta file
     }
 
     # Naming convention for new files
@@ -50,22 +50,31 @@ task ReheaderFile {
     command {
         set -e
 
+        echo "Generating new header file"
         # Extract header from CRAM, modify sample name, and remove @PG lines
         samtools view -H ~{input_cram} > header
         sed --expression='s/SM:~{old_sample}/SM:~{new_sample}/g' header > remapped_header
         grep -v '^@PG' remapped_header > updated_header
 
+        echo "Reheadering cram file"
         # Reheader the CRAM file with updated header
         samtools reheader -P updated_header ~{input_cram} > ~{new_cram}
 
+        echo "Generating md5 file"
         # Generate MD5 checksum for the new CRAM file
         md5sum ~{new_cram} > ~{new_md5}
 
-        # Prepare REF_CACHE for indexing the CRAM file
-        seq_cache_populate.pl -root ./ref/cache ~{ref_fasta}
-        export REF_PATH=:
-        export REF_CACHE=./ref/cache/%2s/%2s/%s
+        if [ ! -z "~{ref_fasta}" ]; then
+            echo "Loading reference cache to help in indexing cram file"
+            # Prepare REF_CACHE for indexing the CRAM file
+            seq_cache_populate.pl -root ./ref/cache ~{ref_fasta}
+            export REF_PATH=:
+            export REF_CACHE=./ref/cache/%2s/%2s/%s
+        else
+            echo "No reference was provided, not creating cache"
+        fi
 
+        echo "Generating index file"
         # Index the new CRAM file
         samtools index ~{new_cram} > ~{new_crai}
     }

--- a/wdl/ReheaderCram/ReheaderCram.wdl
+++ b/wdl/ReheaderCram/ReheaderCram.wdl
@@ -1,0 +1,88 @@
+version 1.0
+
+# Workflow for reheadering a CRAM file.
+# The workflow takes an input CRAM file, a reference genome, and changes the sample name in the CRAM header.
+workflow ReaheaderCram {
+    input {
+        File input_cram         # Input CRAM file to be reheadered
+        String old_sample       # Original sample name in the CRAM file
+        String new_sample       # New sample name to replace the original
+        File ref_fasta          # Reference genome fasta file
+        File ref_fasta_index    # Index for the reference genome fasta file
+    }
+
+    # Main task call to perform reheadering
+    call ReheaderFile {
+        input:
+            input_cram = input_cram,
+            old_sample = old_sample,
+            new_sample = new_sample,
+            ref_fasta = ref_fasta,
+            ref_fasta_index = ref_fasta_index,
+    }
+
+    # Output of the workflow includes the new CRAM file, its index, and MD5 checksum.
+    output {
+        File cram_path = ReheaderFile.new_cram
+        File crai_path = ReheaderFile.new_crai
+        File md5_path = ReheaderFile.new_md5
+    }
+}
+
+# Task definition for reheadering a CRAM file.
+task ReheaderFile {
+    input {
+        File input_cram         # Input CRAM file to be reheadered
+        String old_sample       # Original sample name in the CRAM file
+        String new_sample       # New sample name to replace the original
+        File ref_fasta          # Reference genome fasta file
+        File ref_fasta_index    # Index for the reference genome fasta file
+    }
+
+    # Naming convention for new files
+    String new_cram = new_sample + ".cram"
+    String new_crai = new_sample + ".cram.crai"
+    String new_md5 = new_sample + ".cram.md5"
+
+    # Calculate the required disk size based on input file sizes
+    Int disk_size = ceil((2 * size(input_cram, "GiB")) + size(ref_fasta, "GiB") + size(ref_fasta_index, "GiB")) + 20
+
+    command {
+        set -e
+
+        # Extract header from CRAM, modify sample name, and remove @PG lines
+        samtools view -H ~{input_cram} > header
+        sed --expression='s/SM:~{old_sample}/SM:~{new_sample}/g' header > remapped_header
+        grep -v '^@PG' remapped_header > updated_header
+
+        # Reheader the CRAM file with updated header
+        samtools reheader -P updated_header ~{input_cram} > ~{new_cram}
+
+        # Generate MD5 checksum for the new CRAM file
+        md5sum ~{new_cram} > ~{new_md5}
+
+        # Prepare REF_CACHE for indexing the CRAM file
+        seq_cache_populate.pl -root ./ref/cache ~{ref_fasta}
+        export REF_PATH=:
+        export REF_CACHE=./ref/cache/%2s/%2s/%s
+
+        # Index the new CRAM file
+        samtools index ~{new_cram} > ~{new_crai}
+    }
+
+    # Runtime parameters including docker image, memory, CPU, disk, and retries
+    runtime {
+        docker: "us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616"
+        preemptible: 3
+        memory: "7 GiB"
+        cpu: "1"
+        disks: "local-disk " + disk_size + " HDD"
+    }
+
+    # Output files from the task
+    output {
+        File new_cram = "~{new_cram}"
+        File new_crai = "~{new_crai}"
+        File new_md5 = "~{new_md5}"
+    }
+}


### PR DESCRIPTION
[POD-2481](https://broadinstitute.atlassian.net/browse/POD-2481)
As part of testing out the reheadering workflow originally written in [horsefish](https://github.com/broadinstitute/horsefish/blob/main/scripts/reheader/reheader_cram.wdl), we're adding the workflow to the ops-terra-utils repo. These workflows have been tested in [this workspace](https://app.terra.bio/#workspaces/ops-integration-billing/NS_Test_Reahdering_Workflows/data).  

[POD-2481]: https://broadinstitute.atlassian.net/browse/POD-2481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ