### PR TITLE
POD-2577: Add workflow to reheader arrays 

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -174,3 +174,10 @@ workflows:
     readMePath: /wdl/CleanUpStagingWorkspace/README.md
     testParameterFiles:
       - /wdl/CleanUpStagingWorkspace/CleanUpStagingWorkspace.wdl
+
+  - name: ReheaderArraysVcf
+    subclass: WDL
+    primaryDescriptorPath: /wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
+    readMePath: /wdl/ReheaderArraysVcf/README.md
+    testParameterFiles:
+      - /wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl

--- a/wdl/ReheaderArraysVcf/README.md
+++ b/wdl/ReheaderArraysVcf/README.md
@@ -1,0 +1,20 @@
+# WDL Input Overview
+
+This WDL script re-headers a VCF file using picard tools. This can be used when a sample name has changed, and the VCF
+header needs to be updated to replace the old sample alias with the new sample alias. Note that this can only be
+used on single-sample VCF (your workflow will fail if provided with a multi-sample vcf, for example the output of
+joint calling). The original sample alias doesn't need to be provided. It will be extracted automatically from the
+VCF input.
+
+## Inputs Table:
+| Input Name               | Description                        | Type   | Required | Default  |
+|--------------------------|------------------------------------|--------|----------|----------|
+| **input_vcf**            | The path to the original VCF file. | File   | Yes      | N/A      |
+| **new_sample_alias**     | The NEW sample alias.              | String | Yes      | N/A      |
+| **chipwell_barcode**     | The sample's chipwell barcode.     | String | Yes      | N/A      |
+
+## Outputs Table:
+| Output Name                 | Description                                                | Type |
+|-----------------------------|------------------------------------------------------------|------|
+| **reheadered_vcf**          | The path to the new re-headered vcf                        | File |
+| **reheadered_vcf_index**    | The path to the new index file associated with the new vcf | File |

--- a/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
+++ b/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
@@ -48,8 +48,10 @@ task ReplaceSampleAlias {
         echo "Getting original sample alias from vcf"
         original_sample_alias=$(zgrep 'sampleAlias' ~{input_vcf} | cut -d'=' -f2)
 
+        echo "Found original sample alias: $original_sample_alias "
+
         echo "Updating VCF to replace the original sample alias with the new sample alias"
-        gunzip -c  ~{input_vcf} | sed 's/$original_sample_alias/~{new_sample_alias}/g' | gzip > ~{reheadered_vcf}
+        gunzip -c  ~{input_vcf} | sed "s/$original_sample_alias/~{new_sample_alias}/g" | gzip > ~{reheadered_vcf}
 
     }
 

--- a/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
+++ b/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
@@ -1,0 +1,104 @@
+version 1.0
+
+
+workflow ReheaderArraysVcfFile {
+    input {
+        File input_vcf
+        String new_sample_alias
+        String chipwell_barcode
+    }
+
+    call ReplaceSampleAlias {
+        input:
+            input_vcf = input_vcf,
+            new_sample_alias = new_sample_alias,
+            chipwell_barcode = chipwell_barcode
+    }
+
+    call ReheaderVCF {
+        input:
+            vcf = ReplaceSampleAlias.reheadered_vcf,
+            chipwell_barcode = chipwell_barcode,
+            new_sample_alias = new_sample_alias
+    }
+
+    output {
+        File reheadered_vcf = ReheaderVCF.reheadered_vcf
+        File reheadered_vcf_index = ReheaderVCF.reheadered_vcf_index
+    }
+
+}
+
+task ReplaceSampleAlias {
+    input {
+        File input_vcf
+        String new_sample_alias
+        String chipwell_barcode
+
+        Int cpu = 1
+        Int memory_mb = 16000
+        Int disk_size_gb = ceil(3 * size(input_vcf, "GiB")) + 60
+    }
+
+    String reheadered_vcf = chipwell_barcode + ".vcf.gz"
+
+    command {
+        set -e
+
+        echo "Getting original sample alias from vcf"
+        original_sample_alias=$(zgrep 'sampleAlias' ~{input_vcf} | cut -d'=' -f2)
+
+        echo "Updating VCF to replace the original sample alias with the new sample alias"
+        gunzip -c  ~{input_vcf} | sed 's/$original_sample_alias/~{new_sample_alias}/g' | gzip > ~{reheadered_vcf}
+
+    }
+
+    runtime {
+        docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.11"
+        cpu: cpu
+        memory: "~{memory_mb} MiB"
+        disks: "local-disk ~{disk_size_gb} HDD"
+
+    }
+
+    output {
+        File reheadered_vcf = "~{reheadered_vcf}"
+    }
+}
+
+
+task ReheaderVCF {
+    input {
+        File vcf
+        String chipwell_barcode
+        String new_sample_alias
+
+        Int cpu = 1
+        Int memory_mb = 16000
+        Int disk_size_gb = ceil(3 * size(vcf, "GiB")) + 60
+    }
+
+    String reheadered_vcf = chipwell_barcode + ".vcf.gz"
+    String reheadered_vcf_index = reheadered_vcf + ".tbi"
+
+    command <<<
+        java -jar /usr/picard/picard.jar RenameSampleInVcf \
+        INPUT=~{vcf} \
+        OUTPUT=~{reheadered_vcf} \
+        NEW_SAMPLE_NAME=~{new_sample_alias} \
+        CREATE_INDEX=true
+    >>>
+
+    output {
+        File reheadered_vcf = "~{reheadered_vcf}"
+        File reheadered_vcf_index = "~{reheadered_vcf_index}"
+    }
+
+    runtime {
+        docker: "us.gcr.io/broad-gotc-prod/picard-cloud:2.26.11"
+        cpu: cpu
+        memory: "~{memory_mb} MiB"
+        disks: "local-disk ~{disk_size_gb} HDD"
+    }
+
+}

--- a/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
+++ b/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
@@ -45,11 +45,15 @@ task ReplaceSampleAlias {
     command {
         set -e
 
+        # This step is necessary in the event that the alias populated in the `sampleAlias` field is not the same as
+        the one populated in the file header
+
+        # Get the original sample alias by using zgrep (zgrep is required if files are compressed)
         echo "Getting original sample alias from vcf"
         original_sample_alias=$(zgrep 'sampleAlias' ~{input_vcf} | cut -d'=' -f2)
-
         echo "Found original sample alias: $original_sample_alias "
 
+        # Use sed to replace the original sample alias with the new one provided
         echo "Updating VCF to replace the original sample alias with the new sample alias"
         gunzip -c  ~{input_vcf} | sed "s/$original_sample_alias/~{new_sample_alias}/g" | gzip > ~{reheadered_vcf}
 
@@ -84,6 +88,9 @@ task ReheaderVCF {
     String reheadered_vcf_index = reheadered_vcf + ".tbi"
 
     command <<<
+        # Use the picard tool to change the alias that's present in the actual header of the file. This also outputs
+        a new index file
+
         java -jar /usr/picard/picard.jar RenameSampleInVcf \
         INPUT=~{vcf} \
         OUTPUT=~{reheadered_vcf} \

--- a/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
+++ b/wdl/ReheaderArraysVcf/ReheaderArraysVcf.wdl
@@ -46,12 +46,12 @@ task ReplaceSampleAlias {
         set -e
 
         # This step is necessary in the event that the alias populated in the `sampleAlias` field is not the same as
-        the one populated in the file header
+        # the one populated in the actual file header
 
         # Get the original sample alias by using zgrep (zgrep is required if files are compressed)
         echo "Getting original sample alias from vcf"
         original_sample_alias=$(zgrep 'sampleAlias' ~{input_vcf} | cut -d'=' -f2)
-        echo "Found original sample alias: $original_sample_alias "
+        echo "Found original sample alias: $original_sample_alias"
 
         # Use sed to replace the original sample alias with the new one provided
         echo "Updating VCF to replace the original sample alias with the new sample alias"
@@ -89,7 +89,7 @@ task ReheaderVCF {
 
     command <<<
         # Use the picard tool to change the alias that's present in the actual header of the file. This also outputs
-        a new index file
+        # a new index file
 
         java -jar /usr/picard/picard.jar RenameSampleInVcf \
         INPUT=~{vcf} \


### PR DESCRIPTION
[POD-2577](https://broadinstitute.atlassian.net/browse/POD-2577)

To support FARA, we're making a script that can reheader arrays VCF files. It will take the old sample alias and replace it with the new one within the vcf header. 

[POD-2577]: https://broadinstitute.atlassian.net/browse/POD-2577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ