### PR TITLE
POD-2589: Remove call to deprecated Terra endpoint 

### DIFF
--- a/python/hard_clone_workspace.py
+++ b/python/hard_clone_workspace.py
@@ -275,13 +275,11 @@ if __name__ == '__main__':
     src_auth_domain = src_workspace_info["workspace"]["authorizationDomain"]
     src_bucket = src_workspace_info["workspace"]["bucketName"]
 
-    # Separate the source workspace attributes into src and library attributes
+    # Gather the workspace attributes. Functionality for library attributes has been
+    # deprecated, and we do not need to collect existing library attributes
     src_attributes = {}
-    library_attributes = {}
     for k, v in src_workspace_info['workspace']['attributes'].items():
-        if k.startswith('library:'):
-            library_attributes[k] = v
-        else:
+        if not k.startswith('library:'):
             src_attributes[k] = v
 
     # Create the destination workspace
@@ -301,10 +299,6 @@ if __name__ == '__main__':
         )
         bucket_to_check = external_bucket if external_bucket else dest_workspace.get_workspace_bucket()
         check_and_wait_for_permissions(bucket=bucket_to_check, total_hours=total_hours)
-
-    # Add the library attributes to the destination workspace if they exist
-    if library_attributes:
-        dest_workspace.put_metadata_for_library_dataset(library_metadata=library_attributes)
 
     dest_workspace_info = dest_workspace.get_workspace_info()
     dest_bucket = dest_workspace_info["workspace"]["bucketName"]

--- a/python/tests/integration_tests/test_terra_util.py
+++ b/python/tests/integration_tests/test_terra_util.py
@@ -78,18 +78,6 @@ def test_update_user_acl():
     assert res["usersUpdated"][0]["email"] == email
 
 
-def test_put_metadata_for_library_dataset():
-    bucket = terra_workspace.get_workspace_bucket()
-    library_metadata = {"library:dulvn": 1}
-    res = terra_workspace.put_metadata_for_library_dataset(library_metadata=library_metadata)
-    assert res["namespace"] == INTEGRATION_TEST_TERRA_BILLING_PROJECT
-    assert res["name"] == INTEGRATION_TEST_TERRA_WORKSPACE_NAME
-    assert res["bucketName"] == bucket
-    assert res["attributes"] == library_metadata
-    assert res["name"] == INTEGRATION_TEST_TERRA_WORKSPACE_NAME
-    assert res["namespace"] == INTEGRATION_TEST_TERRA_BILLING_PROJECT
-
-
 def test_update_multiple_users_acl():
     acl_list = [
         {

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -1,3 +1,7 @@
+import warnings
+import functools
+
+
 GCP = "gcp"
 AZURE = "azure"
 ARG_DEFAULTS = {
@@ -17,3 +21,20 @@ ARG_DEFAULTS = {
 def comma_separated_list(value: str) -> list:
     """Return a list of values from a comma-separated string. Can be used as type in argparse."""
     return value.split(",")
+
+
+# A wrapper function to be used for deprecated functionality. Use the @deprecated
+# decorator for a function and provide a reason. Anytime the function is called, a
+# deprecation warning will be raised.
+def deprecated(reason: str):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                f"{func.__name__} is deprecated: {reason}",
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/python/utils/terra_utils/terra_util.py
+++ b/python/utils/terra_utils/terra_util.py
@@ -531,7 +531,7 @@ class TerraWorkspace:
             )
         return request_json
 
-    @deprecated("Firecloud functionality has been sunset. There is currently no support for this functionality.")
+    @deprecated("Firecloud functionality has been sunset. There is currently no support for adding library attributes in Terra.")
     def put_metadata_for_library_dataset(self, library_metadata: dict, validate: bool = False) -> dict:
         """
         THIS FUNCTION HAS BEEN DEPRECATED

--- a/python/utils/terra_utils/terra_util.py
+++ b/python/utils/terra_utils/terra_util.py
@@ -4,8 +4,7 @@ import re
 from typing import Any, Optional
 from urllib.parse import urlparse
 
-from .. import GCP
-
+from .. import GCP, deprecated
 from ..requests_utils.request_util import GET, POST, PATCH, PUT, DELETE
 
 TERRA_LINK = "https://api.firecloud.org/api"
@@ -532,8 +531,11 @@ class TerraWorkspace:
             )
         return request_json
 
+    @deprecated("Firecloud functionality has been sunset. There is currently no support for this functionality.")
     def put_metadata_for_library_dataset(self, library_metadata: dict, validate: bool = False) -> dict:
         """
+        THIS FUNCTION HAS BEEN DEPRECATED
+
         Update the metadata for a library dataset.
 
         Args:

--- a/wdl/HardCloneWithExternalBucket/README.md
+++ b/wdl/HardCloneWithExternalBucket/README.md
@@ -6,11 +6,11 @@ This WDL script creates a new workspace that is nearly identical to the source w
 >Library attributes are no longer supported with Terra. If your source workspace has library attributes, they will
 > not be copied to the cloned workspace.
 
->[!WARNING]
+>[!IMPORTANT]
 > **If you are NOT an OWNER of the original workspace, use the `do_not_update_acls` option.** If you do not use it, and
 > you are not an OWNER, this script will run into issues when trying to get ACLs of the source workspace.
 
->[!WARNING]
+>[!IMPORTANT]
 > Make sure your Terra "Proxy Group" has full access to the external_bucket.
 
 ## Inputs Table:

--- a/wdl/HardCloneWithExternalBucket/README.md
+++ b/wdl/HardCloneWithExternalBucket/README.md
@@ -2,10 +2,16 @@
 
 This WDL script creates a new workspace that is nearly identical to the source workspace. It updates all metadata and copies all files to the GCP external_bucket passed in. Note that if metadata contains references to other tables, they may not transfer correctly and might appear as dictionaries or JSON in the new workspace.
 
-## Notes
+>[!CAUTION]
+>Library attributes are no longer supported with Terra. If your source workspace has library attributes, they will
+> not be copied to the cloned workspace.
 
-*  **If you are NOT an OWNER of the original workspace use do_not_update_acls option.** If you do not use it, and you are not an OWNER, this script will run into issues when trying get ACLs of the source workspace.
-* Make sure your Terra "Proxy Group" has full access to the external_bucket.
+>[!WARNING]
+> **If you are NOT an OWNER of the original workspace, use the `do_not_update_acls` option.** If you do not use it, and
+> you are not an OWNER, this script will run into issues when trying to get ACLs of the source workspace.
+
+>[!WARNING]
+> Make sure your Terra "Proxy Group" has full access to the external_bucket.
 
 ## Inputs Table:
 

--- a/wdl/HardCloneWorkspace/README.md
+++ b/wdl/HardCloneWorkspace/README.md
@@ -2,7 +2,13 @@
 
 This WDL script creates a new workspace that is nearly identical to the source workspace. It updates all metadata to point towards the new bucket and copies all files into this new bucket. Note that if metadata contains references to other tables, they may not transfer correctly and might appear as dictionaries or JSON in the new workspace.
 
-**If you are NOT an OWNER of the original workspace use do_not_update_acls option.** If you do not use it, and you are not an OWNER, this script will run into issues when trying get ACLs of the source workspace.
+>[!CAUTION]
+>Library attributes are no longer supported with Terra. If your source workspace has library attributes, they will
+> not be copied to the cloned workspace.
+
+>[!WARNING]
+> **If you are NOT an OWNER of the original workspace, use the `do_not_update_acls` option.** If you do not use it, and
+> you are not an OWNER, this script will run into issues when trying to get ACLs of the source workspace.
 
 ## Inputs Table:
 

--- a/wdl/HardCloneWorkspace/README.md
+++ b/wdl/HardCloneWorkspace/README.md
@@ -6,7 +6,7 @@ This WDL script creates a new workspace that is nearly identical to the source w
 >Library attributes are no longer supported with Terra. If your source workspace has library attributes, they will
 > not be copied to the cloned workspace.
 
->[!WARNING]
+>[!IMPORTANT]
 > **If you are NOT an OWNER of the original workspace, use the `do_not_update_acls` option.** If you do not use it, and
 > you are not an OWNER, this script will run into issues when trying to get ACLs of the source workspace.
 


### PR DESCRIPTION
[POD-2589](https://broadinstitute.atlassian.net/browse/POD-2589)

The PutLibraryMetadata endpoint has been deprecated as part of the sunsetting of the FireCloud UI. See Terra support ticket [here](https://broadinstitute.zendesk.com/agent/tickets/327323).

This change removes calls the deprecated endpoint, and marks the endpoint as such. READMEs for the hard-clone workflows were updated to indicate that this functionality is no longer supported, and that cloned workspace will not have library attributes, even if their source workspace did. 