### PR TITLE
POD-2656: Use consistent GCP file writing function

### DIFF
--- a/python/combine_metrics_files.py
+++ b/python/combine_metrics_files.py
@@ -114,5 +114,5 @@ if __name__ == '__main__':
     ).run()
     # Write the combined metrics to the output file
     logging.info(f"Writing to {output_gcp_path}")
-    gcp_functions.write_to_gcs(cloud_path=output_gcp_path, content='\n'.join(full_metrics_list))
+    gcp_functions.write_to_gcp_file(cloud_path=output_gcp_path, file_contents='\n'.join(full_metrics_list))
     logging.info(f"Finished writing to {output_gcp_path}")

--- a/python/make_feature_workspace.py
+++ b/python/make_feature_workspace.py
@@ -38,9 +38,9 @@ class UploadJsonAndSetPermissions:
     def run(self, file_contents_json: dict, file_name: str) -> None:
         full_cloud_path = os.path.join(f'gs://{self.bucket_name}/', file_name)
         logging.info(f"Uploading {file_name} to {full_cloud_path} and updating permissions")
-        self.gcp_utils.write_to_gcs(
+        self.gcp_utils.write_to_gcp_file(
             cloud_path=full_cloud_path,
-            content=json.dumps(file_contents_json, indent=4)
+            file_contents=json.dumps(file_contents_json, indent=4)
         )
         self.gcp_utils.set_acl_public_read(cloud_path=full_cloud_path)
         self.gcp_utils.set_acl_group_owner(cloud_path=full_cloud_path, group_email=self.comms_group)


### PR DESCRIPTION
Relates to: https://github.com/broadinstitute/pyops-service-toolkit/pull/31 