### PR TITLE
Add a script to delete a list of files from a dataset

### DIFF
--- a/python/delete_dataset_files_by_id.py
+++ b/python/delete_dataset_files_by_id.py
@@ -72,7 +72,7 @@ class DeleteDatasetFilesById:
                 snapshots_to_delete.append(snap_id)
         if snapshots_to_delete:
             logging.info(
-                f"{"[Dry run] " if self.dry_run else ""}Deleting {len(snapshots_to_delete)} snapshots that reference "
+                f"{'[Dry run] ' if self.dry_run else ''}Deleting {len(snapshots_to_delete)} snapshots that reference "
                 "target files")
             if not self.dry_run:
                 for snap_id in snapshots_to_delete:
@@ -90,7 +90,7 @@ class DeleteDatasetFilesById:
         self._delete_snapshots()
 
         logging.info(
-            f"{"[Dry run] " if self.dry_run else ""}Submitting delete request for {len(self.file_id_set)} files in "
+            f"{'[Dry run] ' if self.dry_run else ''}Submitting delete request for {len(self.file_id_set)} files in "
             f"dataset {self.dataset_id}")
         if not self.dry_run:
             self.tdr.delete_files(

--- a/python/delete_dataset_files_by_id.py
+++ b/python/delete_dataset_files_by_id.py
@@ -3,7 +3,6 @@ from argparse import ArgumentParser, Namespace
 
 from ops_utils.request_util import RunRequest
 from ops_utils.tdr_utils.tdr_api_utils import TDR
-from ops_utils.tdr_utils.tdr_job_utils import MonitorTDRJob
 from ops_utils.token_util import Token
 
 logging.basicConfig(
@@ -41,70 +40,13 @@ def get_args() -> Namespace:
     return parser.parse_args()
 
 
-class DeleteDatasetFilesById:
-    """Class to delete files from a TDR dataset by their IDs, handling snapshots."""
-
-    def __init__(self, tdr: TDR, dataset_id: str, file_id_set: set[str], dry_run: bool = False):
-        self.tdr = tdr
-        self.dataset_id = dataset_id
-        self.dry_run = dry_run
-        self.file_id_set = file_id_set
-
-    def _delete_snapshots(self) -> None:
-        """Delete snapshots that reference any of the provided file IDs."""
-        snapshots_resp = self.tdr.get_dataset_snapshots(dataset_id=self.dataset_id)
-        snapshot_items = snapshots_resp.json().get('items', [])
-        snapshots_to_delete = []
-        logging.info(
-            "Checking %d snapshots for references",
-            len(snapshot_items),
-        )
-        for snap in snapshot_items:
-            snap_id = snap.get('id')
-            if not snap_id:
-                continue
-            snap_files = self.tdr.get_files_from_snapshot(snapshot_id=snap_id)
-            snap_file_ids = {
-                fd.get('fileId') for fd in snap_files if fd.get('fileId')
-            }
-            # Use set intersection to check for any matching file IDs
-            if snap_file_ids & self.file_id_set:
-                snapshots_to_delete.append(snap_id)
-        if snapshots_to_delete:
-            logging.info(
-                f"{'[Dry run] ' if self.dry_run else ''}Deleting {len(snapshots_to_delete)} snapshots that reference "
-                "target files")
-            if not self.dry_run:
-                for snap_id in snapshots_to_delete:
-                    job_id = self.tdr.delete_snapshot(snap_id).json()['id']
-                    MonitorTDRJob(
-                        tdr=self.tdr,
-                        job_id=job_id,
-                        check_interval=10,
-                        return_json=False
-                    ).run()
-        else:
-            logging.info("No snapshots reference the provided file ids")
-
-    def delete_files_and_snapshots(self) -> None:
-        self._delete_snapshots()
-
-        logging.info(
-            f"{'[Dry run] ' if self.dry_run else ''}Submitting delete request for {len(self.file_id_set)} files in "
-            f"dataset {self.dataset_id}")
-        if not self.dry_run:
-            self.tdr.delete_files(
-                file_ids=list(self.file_id_set),
-                dataset_id=self.dataset_id
-            )
-
-
 if __name__ == '__main__':
     args = get_args()
     service_account_json = args.service_account_json
 
     token = Token(service_account_json=service_account_json)
     request_util = RunRequest(token=token)
+    tdr = TDR(request_util=request_util, dry_run=args.dry_run)
     file_list = args.file_list
 
     with open(file_list, 'r') as f:
@@ -114,10 +56,4 @@ if __name__ == '__main__':
         logging.info("No file ids provided; nothing to delete")
     else:
         logging.info(f"Found {len(file_ids)} file ids in {file_list} to delete")
-
-        DeleteDatasetFilesById(
-            tdr=TDR(request_util=request_util),
-            dataset_id=args.dataset_id,
-            file_id_set=file_ids,
-            dry_run=args.dry_run
-        ).delete_files_and_snapshots()
+        tdr.delete_files_and_snapshots(dataset_id=args.dataset_id, file_ids=file_ids)

--- a/python/delete_dataset_files_by_id.py
+++ b/python/delete_dataset_files_by_id.py
@@ -72,10 +72,8 @@ class DeleteDatasetFilesById:
                 snapshots_to_delete.append(snap_id)
         if snapshots_to_delete:
             logging.info(
-                "%sDeleting %d snapshots that reference target files",
-                "[Dry run] " if self.dry_run else "",
-                len(snapshots_to_delete),
-            )
+                f"{"[Dry run] " if self.dry_run else ""}Deleting {len(snapshots_to_delete)} snapshots that reference "
+                f"target files")
             if not self.dry_run:
                 for snap_id in snapshots_to_delete:
                     job_id = self.tdr.delete_snapshot(snap_id).json()['id']
@@ -92,11 +90,8 @@ class DeleteDatasetFilesById:
         self._delete_snapshots()
 
         logging.info(
-            "%sSubmitting delete request for %d files in dataset %s",
-            "[Dry run] " if self.dry_run else "",
-            len(self.file_id_set),
-            self.dataset_id,
-        )
+            f"{"[Dry run] " if self.dry_run else ""}Submitting delete request for {len(self.file_id_set)} files in "
+            f"dataset {self.dataset_id}")
         if not self.dry_run:
             self.tdr.delete_files(
                 file_ids=list(self.file_id_set),
@@ -118,11 +113,8 @@ if __name__ == '__main__':
     if not file_ids:
         logging.info("No file ids provided; nothing to delete")
     else:
-        logging.info(
-            "Found %d file ids in %s to delete",
-            len(file_ids),
-            file_list,
-        )
+        logging.info(f"Found {len(file_ids)} file ids in {file_list} to delete")
+
         DeleteDatasetFilesById(
             tdr=TDR(request_util=request_util),
             dataset_id=args.dataset_id,

--- a/python/delete_dataset_files_by_id.py
+++ b/python/delete_dataset_files_by_id.py
@@ -73,7 +73,7 @@ class DeleteDatasetFilesById:
         if snapshots_to_delete:
             logging.info(
                 f"{"[Dry run] " if self.dry_run else ""}Deleting {len(snapshots_to_delete)} snapshots that reference "
-                f"target files")
+                "target files")
             if not self.dry_run:
                 for snap_id in snapshots_to_delete:
                     job_id = self.tdr.delete_snapshot(snap_id).json()['id']

--- a/python/delete_datset_files_by_id.py
+++ b/python/delete_datset_files_by_id.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser, Namespace
 
 from ops_utils.request_util import RunRequest
 from ops_utils.tdr_utils.tdr_api_utils import TDR
-from ops_utils.tdr_utils.tdr_job_utils import MonitorTDRJob, SubmitAndMonitorMultipleJobs
+from ops_utils.tdr_utils.tdr_job_utils import MonitorTDRJob
 from ops_utils.token_util import Token
 
 logging.basicConfig(
@@ -111,13 +111,10 @@ class DeleteDatasetFilesById:
             self.dataset_id,
         )
         if not self.dry_run:
-            SubmitAndMonitorMultipleJobs(
-                tdr=self.tdr,
-                job_function=self.tdr.delete_file,
-                job_args_list=[(file_id, self.dataset_id) for file_id in file_ids],
-                batch_size=200,
-                check_interval=15
-            ).run()
+            self.tdr.delete_files(
+                file_ids=list(file_ids),
+                dataset_id=self.dataset_id
+            )
 
 
 if __name__ == '__main__':

--- a/python/delete_datset_files_by_id.py
+++ b/python/delete_datset_files_by_id.py
@@ -1,0 +1,133 @@
+import logging
+from argparse import ArgumentParser, Namespace
+
+from ops_utils.request_util import RunRequest
+from ops_utils.tdr_utils.tdr_api_utils import TDR
+from ops_utils.tdr_utils.tdr_job_utils import MonitorTDRJob, SubmitAndMonitorMultipleJobs
+from ops_utils.token_util import Token
+
+logging.basicConfig(
+    format="%(levelname)s: %(asctime)s : %(message)s", level=logging.INFO
+)
+
+def get_args() -> Namespace:
+    """Parse CLI args for deleting dataset files and related snapshots."""
+    parser = ArgumentParser(description="Delete dataset files by ID")
+    parser.add_argument("-id", "--dataset_id", required=True)
+    parser.add_argument(
+        "-f",
+        "--file_list",
+        required=True,
+        help="Path to file with file UUIDs (one per line)",
+    )
+    parser.add_argument(
+        "--service_account_json",
+        "-saj",
+        type=str,
+        help=(
+            "Path to service account JSON. Uses default "
+            "credentials if omitted."
+        ),
+    )
+    parser.add_argument(
+        "--dry_run",
+        "-n",
+        action="store_true",
+        help=(
+            "Do not perform deletions; log actions that would be taken."
+        ),
+    )
+    return parser.parse_args()
+
+class DeleteDatasetFilesById:
+    """Class to delete files from a TDR dataset by their IDs, handling snapshots."""
+
+    def __init__(self, tdr: TDR, dataset_id: str, file_list: str, dry_run: bool = False):
+        self.tdr = tdr
+        self.dataset_id = dataset_id
+        self.dry_run = dry_run
+        self.file_list = file_list
+
+    def delete_snapshots(self, file_ids: set[str]):
+        """Delete snapshots that reference any of the provided file IDs."""
+        snapshots_resp = self.tdr.get_dataset_snapshots(dataset_id=self.dataset_id)
+        snapshot_items = snapshots_resp.json().get('items', [])
+        snapshots_to_delete = []
+        logging.info(
+            "Checking %d snapshots for references",
+            len(snapshot_items),
+        )
+        for snap in snapshot_items:
+            snap_id = snap.get('id')
+            if not snap_id:
+                continue
+            snap_files = self.tdr.get_files_from_snapshot(snapshot_id=snap_id)
+            snap_file_ids = {
+                fd.get('fileId') for fd in snap_files if fd.get('fileId')
+            }
+            # Use set intersection to check for any matching file IDs
+            if snap_file_ids & file_ids:
+                snapshots_to_delete.append(snap_id)
+        if snapshots_to_delete:
+            logging.info(
+                "%sDeleting %d snapshots that reference target files",
+                "[Dry run] " if self.dry_run else "",
+                len(snapshots_to_delete),
+            )
+            if not self.dry_run:
+                for snap_id in snapshots_to_delete:
+                    job_id = self.tdr.delete_snapshot(snap_id).json()['id']
+                    MonitorTDRJob(
+                        tdr=self.tdr,
+                        job_id=job_id,
+                        check_interval=10,
+                        return_json=False
+                    ).run()
+        else:
+            logging.info("No snapshots reference the provided file ids")
+
+    def delete_files_and_snapshots(self) -> None:
+        with open(self.file_list, 'r', encoding='utf-8') as f:
+            file_ids = {line.strip() for line in f if line.strip()}
+
+        if not file_ids:
+            logging.info("No file ids provided; nothing to delete")
+            return
+
+        logging.info(
+            "Found %d file ids in %s to delete",
+            len(file_ids),
+            self.file_list,
+        )
+
+        self.delete_snapshots(file_ids)
+
+        logging.info(
+            "%sSubmitting delete request for %d files in dataset %s",
+            "[Dry run] " if self.dry_run else "",
+            len(file_ids),
+            self.dataset_id,
+        )
+        if not self.dry_run:
+            SubmitAndMonitorMultipleJobs(
+                tdr=self.tdr,
+                job_function=self.tdr.delete_file,
+                job_args_list=[(file_id, self.dataset_id) for file_id in file_ids],
+                batch_size=200,
+                check_interval=15
+            ).run()
+
+
+if __name__ == '__main__':
+    args = get_args()
+    service_account_json = args.service_account_json
+
+    token = Token(service_account_json=service_account_json)
+    request_util = RunRequest(token=token)
+
+    DeleteDatasetFilesById(
+        tdr=TDR(request_util=request_util),
+        dataset_id=args.dataset_id,
+        file_list=args.file_list,
+        dry_run=args.dry_run
+    ).delete_files_and_snapshots()

--- a/python/delete_datset_files_by_id.py
+++ b/python/delete_datset_files_by_id.py
@@ -10,6 +10,7 @@ logging.basicConfig(
     format="%(levelname)s: %(asctime)s : %(message)s", level=logging.INFO
 )
 
+
 def get_args() -> Namespace:
     """Parse CLI args for deleting dataset files and related snapshots."""
     parser = ArgumentParser(description="Delete dataset files by ID")
@@ -39,6 +40,7 @@ def get_args() -> Namespace:
     )
     return parser.parse_args()
 
+
 class DeleteDatasetFilesById:
     """Class to delete files from a TDR dataset by their IDs, handling snapshots."""
 
@@ -48,7 +50,7 @@ class DeleteDatasetFilesById:
         self.dry_run = dry_run
         self.file_list = file_list
 
-    def delete_snapshots(self, file_ids: set[str]):
+    def delete_snapshots(self, file_ids: set[str]) -> None:
         """Delete snapshots that reference any of the provided file IDs."""
         snapshots_resp = self.tdr.get_dataset_snapshots(dataset_id=self.dataset_id)
         snapshot_items = snapshots_resp.json().get('items', [])

--- a/python/delete_tdr_rows.py
+++ b/python/delete_tdr_rows.py
@@ -5,7 +5,7 @@ from ops_utils.tdr_utils.tdr_api_utils import TDR
 from ops_utils.token_util import Token
 import logging
 
-from python.delete_datset_files_by_id import DeleteDatasetFilesById
+from delete_datset_files_by_id import DeleteDatasetFilesById
 
 logging.basicConfig(
     format="%(levelname)s: %(asctime)s : %(message)s", level=logging.INFO

--- a/python/delete_tdr_rows.py
+++ b/python/delete_tdr_rows.py
@@ -5,7 +5,7 @@ from ops_utils.tdr_utils.tdr_api_utils import TDR
 from ops_utils.token_util import Token
 import logging
 
-from delete_datset_files_by_id import DeleteDatasetFilesById
+from delete_dataset_files_by_id import DeleteDatasetFilesById
 
 logging.basicConfig(
     format="%(levelname)s: %(asctime)s : %(message)s", level=logging.INFO
@@ -119,14 +119,16 @@ if __name__ == '__main__':
             logging.info(
                 f"Dry run: would delete {len(tdr_rows_to_delete)} rows from table {table_name} in dataset {dataset_id}")
         else:
+            # Delete files first. If something goes wrong, we need the rows to still be there so we get the file ids
+            # again.
+            if delete_files:
+                if file_uuids:
+                    DeleteDatasetFilesById(
+                        tdr=tdr,
+                        dataset_id=dataset_id,
+                        file_id_set=file_uuids,
+                        dry_run=args.dry_run
+                    ).delete_files_and_snapshots()
+                else:
+                    logging.info("No files to delete")
             tdr.soft_delete_entries(dataset_id=dataset_id, table_name=table_name, datarepo_row_ids=tdr_rows_to_delete)
-        if delete_files:
-            if file_uuids:
-                DeleteDatasetFilesById(
-                    tdr=tdr,
-                    dataset_id=dataset_id,
-                    file_id_set=file_uuids,
-                    dry_run=args.dry_run
-                ).delete_files_and_snapshots()
-            else:
-                logging.info("No files to delete")

--- a/python/delete_tdr_rows.py
+++ b/python/delete_tdr_rows.py
@@ -25,8 +25,8 @@ def get_args() -> Namespace:
                         action="store_true")
     parser.add_argument("--service_account_json", "-saj", type=str,
                         help="Path to the service account JSON file. If not provided, will use the default credentials.")
-    parser.add_argument("--dry_run","-n",
-                        action="store_true",help="Do not perform deletions; log actions that would be taken.")
+    parser.add_argument("--dry_run", "-n",
+                        action="store_true", help="Do not perform deletions; log actions that would be taken.")
     return parser.parse_args()
 
 

--- a/python/delete_tdr_rows.py
+++ b/python/delete_tdr_rows.py
@@ -5,6 +5,8 @@ from ops_utils.tdr_utils.tdr_api_utils import TDR
 from ops_utils.token_util import Token
 import logging
 
+from python.delete_datset_files_by_id import DeleteDatasetFilesById
+
 logging.basicConfig(
     format="%(levelname)s: %(asctime)s : %(message)s", level=logging.INFO
 )
@@ -114,9 +116,11 @@ if __name__ == '__main__':
         tdr.soft_delete_entries(dataset_id=dataset_id, table_name=table_name, datarepo_row_ids=tdr_rows_to_delete)
         if delete_files:
             if file_uuids:
-                tdr.delete_files(
-                    file_ids=list(file_uuids),
-                    dataset_id=dataset_id
-                )
+                DeleteDatasetFilesById(
+                    tdr=tdr,
+                    dataset_id=dataset_id,
+                    file_id_set=file_uuids,
+                    dry_run=False
+                ).delete_files_and_snapshots()
             else:
                 logging.info("No files to delete")

--- a/python/delete_tdr_rows.py
+++ b/python/delete_tdr_rows.py
@@ -115,20 +115,20 @@ if __name__ == '__main__':
     ).run()
 
     if tdr_rows_to_delete:
+        # Delete files first. If something goes wrong, we need the rows to still be there so we get the file ids
+        # again.
+        if delete_files:
+            if file_uuids:
+                DeleteDatasetFilesById(
+                    tdr=tdr,
+                    dataset_id=dataset_id,
+                    file_id_set=file_uuids,
+                    dry_run=args.dry_run
+                ).delete_files_and_snapshots()
+            else:
+                logging.info("No files to delete")
         if args.dry_run:
             logging.info(
                 f"Dry run: would delete {len(tdr_rows_to_delete)} rows from table {table_name} in dataset {dataset_id}")
         else:
-            # Delete files first. If something goes wrong, we need the rows to still be there so we get the file ids
-            # again.
-            if delete_files:
-                if file_uuids:
-                    DeleteDatasetFilesById(
-                        tdr=tdr,
-                        dataset_id=dataset_id,
-                        file_id_set=file_uuids,
-                        dry_run=args.dry_run
-                    ).delete_files_and_snapshots()
-                else:
-                    logging.info("No files to delete")
             tdr.soft_delete_entries(dataset_id=dataset_id, table_name=table_name, datarepo_row_ids=tdr_rows_to_delete)

--- a/python/delete_tdr_rows.py
+++ b/python/delete_tdr_rows.py
@@ -25,6 +25,8 @@ def get_args() -> Namespace:
                         action="store_true")
     parser.add_argument("--service_account_json", "-saj", type=str,
                         help="Path to the service account JSON file. If not provided, will use the default credentials.")
+    parser.add_argument("--dry_run","-n",
+                        action="store_true",help="Do not perform deletions; log actions that would be taken.")
     return parser.parse_args()
 
 
@@ -113,14 +115,18 @@ if __name__ == '__main__':
     ).run()
 
     if tdr_rows_to_delete:
-        tdr.soft_delete_entries(dataset_id=dataset_id, table_name=table_name, datarepo_row_ids=tdr_rows_to_delete)
+        if args.dry_run:
+            logging.info(
+                f"Dry run: would delete {len(tdr_rows_to_delete)} rows from table {table_name} in dataset {dataset_id}")
+        else:
+            tdr.soft_delete_entries(dataset_id=dataset_id, table_name=table_name, datarepo_row_ids=tdr_rows_to_delete)
         if delete_files:
             if file_uuids:
                 DeleteDatasetFilesById(
                     tdr=tdr,
                     dataset_id=dataset_id,
                     file_id_set=file_uuids,
-                    dry_run=False
+                    dry_run=args.dry_run
                 ).delete_files_and_snapshots()
             else:
                 logging.info("No files to delete")

--- a/python/delete_tdr_rows.py
+++ b/python/delete_tdr_rows.py
@@ -5,8 +5,6 @@ from ops_utils.tdr_utils.tdr_api_utils import TDR
 from ops_utils.token_util import Token
 import logging
 
-from delete_dataset_files_by_id import DeleteDatasetFilesById
-
 logging.basicConfig(
     format="%(levelname)s: %(asctime)s : %(message)s", level=logging.INFO
 )
@@ -103,7 +101,7 @@ if __name__ == '__main__':
 
     token = Token(service_account_json=service_account_json)
     request_util = RunRequest(token=token)
-    tdr = TDR(request_util=request_util)
+    tdr = TDR(request_util=request_util, dry_run=args.dry_run)
 
     # Get the rows to delete and the file_uuids
     tdr_rows_to_delete, file_uuids = GetRowAndFileInfo(
@@ -119,12 +117,7 @@ if __name__ == '__main__':
         # again.
         if delete_files:
             if file_uuids:
-                DeleteDatasetFilesById(
-                    tdr=tdr,
-                    dataset_id=dataset_id,
-                    file_id_set=file_uuids,
-                    dry_run=args.dry_run
-                ).delete_files_and_snapshots()
+                tdr.delete_files_and_snapshots(dataset_id=dataset_id, file_ids=file_uuids)
             else:
                 logging.info("No files to delete")
         if args.dry_run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ pyyaml
 humanfriendly
 responses
 gitpython
-git+https://github.com/broadinstitute/pyops-service-toolkit.git@v11.4.0#egg=pyops-service-toolkit
+git+https://github.com/broadinstitute/pyops-service-toolkit.git@v11.7.0#egg=pyops-service-toolkit


### PR DESCRIPTION
Add a script that deletes all files from a dataset, given a list of datarepo fileIDs. Since a file can't be deleted if a snapshot still refers to it, the script will also delete snapshots as needed before deleting a file.

Add support to `delete_tdr_rows.py` to use this new code, so that snapshots that reference files are automatically deleted if the `delete_files` option is enabled. Also added `dry_run` support to `delete_tdr_rows`